### PR TITLE
ci: add pytest CI workflow for automated testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.9.8"
+
+      - name: Install dependencies
+        run: uv sync
+      - name: Run tests
+        run: uv run pytest tests/ -v --log-cli-level=INFO


### PR DESCRIPTION
This commit introduces the first continuous integration workflow for the project, establishing automated testing infrastructure using GitHub Actions. The workflow integrates with the existing testcontainers-based testing setup, which automatically provisions PostgreSQL containers during test execution.

Changes:
- Add `.github/workflows/ci.yml` as the initial CI configuration
- Configure workflow triggers for push and pull requests to main branch
- Set up Ubuntu latest runner with Python 3.12 environment
- Install uv package manager (v0.9.8) using astral-sh/setup-uv action
- Configure dependency installation via `uv sync`
- Execute test suite with `uv run pytest tests/ -v` for verbose output
- Use actions/checkout@v5 and actions/setup-python@v6 for latest stable actions

Why:
This establishes automated quality gates for the project, ensuring all changes to the main branch are validated through the test suite before merging. The CI pipeline leverages testcontainers to automatically spin up isolated PostgreSQL containers during test runs, eliminating the need for external database services or complex CI database configuration. This approach maintains consistency between local development and CI environments while providing fast feedback on code quality. Pinning the uv version to 0.9.8 ensures reproducible builds across CI runs.

Issue: closes #19