### PR TITLE
feat(db): use timezone-aware UTC datetimes for timestamp consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,11 +154,13 @@ The project also includes an evaluation set (`v1.evalset.json`) for testing agen
 - **Query Management**: Future queries will use aiosql with SQL stored in `.sql` files
 - **Migration Strategy**: All migrations include both `upgrade()` and `downgrade()` functions
 - **Environment Config**: Database URL loaded from `.env` file, managed by Alembic
+- **UTC Timestamps**: All timestamp columns use `TIMESTAMPTZ` and Python code uses `datetime.now(timezone.utc)` for timezone-aware UTC datetimes
 
 **Current Schema:**
 - `articles` table: Stores scraped articles with deduplication via unique URL constraint
   - Indexes on `url` and `published_date` for performance
-  - `fetched_at` tracks when article was scraped
+  - `fetched_at` (TIMESTAMPTZ) tracks when article was scraped
+  - `published_date` (TIMESTAMPTZ) stores article publication date
   - `full_text` stores complete article content for classification
 
 ### Web Scraping Ethics

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ The current schema includes:
   - `url` (VARCHAR UNIQUE NOT NULL) - Article URL for deduplication
   - `title` (VARCHAR NOT NULL)
   - `section` (VARCHAR NOT NULL) - e.g., "lead-stories", "news"
-  - `published_date` (TIMESTAMP)
-  - `fetched_at` (TIMESTAMP NOT NULL DEFAULT NOW())
+  - `published_date` (TIMESTAMPTZ)
+  - `fetched_at` (TIMESTAMPTZ NOT NULL DEFAULT NOW())
   - `full_text` (TEXT) - Full article content for classification
   - Indexes on `url` and `published_date`
 

--- a/alembic/versions/2025_11_20_2018-59f8e37f0c42_convert_timestamps_to_timestamptz_for_.py
+++ b/alembic/versions/2025_11_20_2018-59f8e37f0c42_convert_timestamps_to_timestamptz_for_.py
@@ -1,0 +1,42 @@
+"""convert timestamps to timestamptz for utc support
+
+Revision ID: 59f8e37f0c42
+Revises: 399757bac0a6
+Create Date: 2025-11-20 20:18:33.085181
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '59f8e37f0c42'
+down_revision: Union[str, Sequence[str], None] = '399757bac0a6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("""
+        ALTER TABLE articles
+        ALTER COLUMN published_date TYPE TIMESTAMPTZ;
+    """)
+    op.execute("""
+        ALTER TABLE articles
+        ALTER COLUMN fetched_at TYPE TIMESTAMPTZ;
+    """)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("""
+        ALTER TABLE articles
+        ALTER COLUMN published_date TYPE TIMESTAMP;
+    """)
+    op.execute("""
+        ALTER TABLE articles
+        ALTER COLUMN fetched_at TYPE TIMESTAMP;
+    """)

--- a/src/db/models/domain.py
+++ b/src/db/models/domain.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 
@@ -13,7 +13,7 @@ class Article(BaseModel):
     title: str
     section: str
     published_date: datetime | None = None
-    fetched_at: datetime = Field(default_factory=datetime.now)
+    fetched_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     full_text: str | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/tests/db/repositories/test_article_repository.py
+++ b/tests/db/repositories/test_article_repository.py
@@ -2,7 +2,7 @@
 
 import asyncpg
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from src.db.repositories.article_repository import ArticleRepository
 from src.db.models.domain import Article
@@ -20,7 +20,7 @@ class TestInsertArticleHappyPath:
             url="https://example.com/test-article",
             title="Test Article",
             section="news",
-            published_date=datetime(2025, 11, 15),
+            published_date=datetime(2025, 11, 15, tzinfo=timezone.utc),
             full_text="Article content here",
         )
         repository = ArticleRepository()
@@ -341,7 +341,7 @@ class TestInsertArticleEdgeCases:
         db_connection: asyncpg.Connection,
     ):
         # Given: an article without explicit fetched_at
-        before_insert = datetime.now()
+        before_insert = datetime.now(timezone.utc)
         article = Article(
             url="https://example.com/default-fetched-at",
             title="Default Fetched At Article",
@@ -351,7 +351,7 @@ class TestInsertArticleEdgeCases:
 
         # When: the article is inserted
         result = await repository.insert_article(db_connection, article)
-        after_insert = datetime.now()
+        after_insert = datetime.now(timezone.utc)
 
         # Then: returns article with fetched_at close to current time
         assert result.id is not None
@@ -364,7 +364,7 @@ class TestInsertArticleEdgeCases:
         db_connection: asyncpg.Connection,
     ):
         # Given: an article with explicit fetched_at value
-        custom_fetched_at = datetime(2025, 1, 1, 12, 0, 0)
+        custom_fetched_at = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         article = Article(
             url="https://example.com/custom-fetched-at",
             title="Custom Fetched At Article",


### PR DESCRIPTION
  Update all datetime handling to use timezone-aware UTC datetimes instead of
  naive datetimes. This ensures consistent timestamp behavior across the
  application and proper compatibility with PostgreSQL TIMESTAMPTZ columns.

  Changes:
  - Update Article model's fetched_at default to use datetime.now(timezone.utc)
  - Convert all test datetime values to use timezone-aware UTC datetimes
  - Document TIMESTAMPTZ usage pattern in CLAUDE.md development guidelines
  - Update README schema documentation to reflect TIMESTAMPTZ column types

  Why:
  This change establishes a consistent pattern for handling timestamps throughout
  the codebase. Using timezone-aware UTC datetimes prevents subtle bugs that can
  occur when mixing naive and aware datetimes, ensures accurate time comparisons
  in tests, and properly aligns Python datetime objects with PostgreSQL's
  TIMESTAMPTZ columns. This is a best practice for applications that need
  reliable timestamp handling across different environments and time zones.

  Issue: closes #22