### PR TITLE
feat: Add Article Persistence interface

### DIFF
--- a/scripts/validate_pipeline.py
+++ b/scripts/validate_pipeline.py
@@ -117,14 +117,14 @@ async def validate_pipeline(url: str, section: str = "news") -> None:
                 news_source_id=1,  # Jamaica Gleaner
             )
 
-            if result["stored"]:
-                logger.info(f"  ✓ Article stored with ID: {result['article_id']}")
-                logger.info(f"  ✓ Stored {result['classification_count']} classifications")
+            if result.stored:
+                logger.info(f"  ✓ Article stored with ID: {result.article_id}")
+                logger.info(f"  ✓ Stored {result.classification_count} classifications")
 
                 logger.info("\n=== VALIDATION COMPLETE ===")
-                logger.info(f"Article ID: {result['article_id']}")
-                logger.info(f"Title: {result['article'].title}")
-                logger.info(f"Relevant classifications: {result['classification_count']}")
+                logger.info(f"Article ID: {result.article_id}")
+                logger.info(f"Title: {result.article.title}")  # type: ignore
+                logger.info(f"Relevant classifications: {result.classification_count}")
                 logger.info("✓ Pipeline integration successful!")
             else:
                 logger.info("  ⚠ Article already exists in database (duplicate URL)")

--- a/src/article_persistence/base.py
+++ b/src/article_persistence/base.py
@@ -1,0 +1,50 @@
+"""Base protocol for article persistence services."""
+from typing import Protocol
+from config.database import DatabaseConfig
+from src.article_extractor.models import ExtractedArticleContent
+from src.article_classification.models import ClassificationResult
+from .models.domain import ArticleStorageResult
+
+
+class ArticlePersistenceService(Protocol):
+    """
+    Protocol for article persistence services using structural subtyping.
+
+    This Protocol defines the interface for article persistence without
+    requiring inheritance. Any class that implements the
+    store_article_with_classifications() method with the correct signature
+    can be used as an ArticlePersistenceService.
+
+    This enables dependency injection and testability:
+    - No need to inherit from a base class
+    - Duck typing with type safety
+    - Easy to mock in tests
+    """
+
+    async def store_article_with_classifications(
+        self,
+        db_config: DatabaseConfig,
+        extracted: ExtractedArticleContent,
+        url: str,
+        section: str,
+        relevant_classifications: list[ClassificationResult],
+        news_source_id: int = 1,
+    ) -> ArticleStorageResult:
+        """
+        Store an article with its classifications in a single transaction.
+
+        Args:
+            db_config: Database configuration for connection pool
+            extracted: Extracted article content from ArticleExtractionService
+            url: Original article URL
+            section: Article section (e.g., "news", "lead-stories")
+            relevant_classifications: List of relevant classification results
+            news_source_id: Database ID of news source (default: 1 for Jamaica Gleaner)
+
+        Returns:
+            ArticleStorageResult with storage outcome and metadata
+
+        Raises:
+            Exception: If storage fails (not including duplicates)
+        """
+        ...

--- a/src/article_persistence/models/domain.py
+++ b/src/article_persistence/models/domain.py
@@ -111,3 +111,27 @@ class NewsSource(BaseModel):
         if v < 0:
             raise ValueError('Crawl delay must be non-negative')
         return v
+
+
+class ArticleStorageResult(BaseModel):
+    """
+    Result of storing an article with classifications.
+
+    This model represents the outcome of a store operation,
+    including whether the article was stored or already existed,
+    and metadata about the storage operation.
+
+    Attributes:
+        stored: True if article was newly stored, False if duplicate
+        article_id: Database ID of stored article, None if duplicate
+        classification_count: Number of classifications stored with article
+        article: Full Article model if stored, None if duplicate
+        classifications: List of Classification models stored with article
+    """
+    stored: bool
+    article_id: int | None
+    classification_count: int
+    article: Article | None
+    classifications: list[Classification]
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
What:
- Added interface for persistence
- Return ArticleStorageResult model instead of dict after storage

Why:
Using the interface decouples the system, improves testing, and establishes a pattern for the future.