### PR TITLE
feat(discovery): implement multi-feed RSS support for article discovery

### DIFF
--- a/scripts/validate_rss_discovery.py
+++ b/scripts/validate_rss_discovery.py
@@ -1,18 +1,18 @@
 """
-Example script demonstrating RSS-based article discovery.
+Example script demonstrating multi-feed RSS-based article discovery.
 
 This script shows how to use the GleanerRssFeedDiscoverer to discover
-articles from the Jamaica Gleaner RSS feed.
+articles from multiple Jamaica Gleaner RSS feeds.
 
 Usage:
-    uv run python examples/validate_rss_discovery.py
+    uv run python scripts/validate_rss_discovery.py
 """
 
 import asyncio
 import logging
 from datetime import datetime, timezone
 from src.article_discovery.discoverers.gleaner_rss_discoverer import GleanerRssFeedDiscoverer
-from src.article_discovery.models import DiscoveredArticle
+from src.article_discovery.models import DiscoveredArticle, RssFeedConfig
 
 # Configure logging
 logging.basicConfig(
@@ -23,19 +23,33 @@ logger = logging.getLogger(__name__)
 
 
 async def main():
-    """Run RSS discovery example."""
-    logger.info("Starting RSS Discovery Example")
+    """Run multi-feed RSS discovery example."""
+    logger.info("Starting Multi-Feed RSS Discovery Example")
     logger.info("=" * 70)
 
+    # Configure multiple RSS feeds
+    feed_configs = [
+        RssFeedConfig(
+            url="https://jamaica-gleaner.com/feed/rss.xml",
+            section="lead-stories"
+        ),
+        RssFeedConfig(
+            url="https://jamaica-gleaner.com/feed/news.xml",
+            section="news"
+        )
+    ]
+
+    logger.info(f"Configured {len(feed_configs)} RSS feeds:")
+    for i, config in enumerate(feed_configs, 1):
+        logger.info(f"  {i}. {config.url} (section: {config.section})")
+    logger.info("")
+
     # Initialize the RSS discoverer
-    discoverer = GleanerRssFeedDiscoverer(
-        feed_url="https://jamaica-gleaner.com/feed/rss.xml",
-        section="lead-stories",
-    )
+    discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
     try:
-        # Discover articles from the RSS feed
-        logger.info("Discovering articles from Jamaica Gleaner RSS feed...")
+        # Discover articles from all RSS feeds
+        logger.info("Discovering articles from Jamaica Gleaner RSS feeds...")
         articles: list[DiscoveredArticle] = await discoverer.discover(news_source_id=1)
 
         # Display results
@@ -54,6 +68,16 @@ async def main():
         logger.info("=" * 70)
         logger.info("Summary:")
         logger.info(f"  Total articles discovered: {len(articles)}")
+
+        # Per-section statistics
+        sections = {}
+        for article in articles:
+            sections[article.section] = sections.get(article.section, 0) + 1
+
+        logger.info("  Articles by section:")
+        for section, count in sorted(sections.items()):
+            logger.info(f"    {section}: {count}")
+
         logger.info(f"  Articles with titles: {sum(1 for a in articles if a.title)}")
         logger.info(f"  Articles with dates: {sum(1 for a in articles if a.published_date)}")
         logger.info("=" * 70)

--- a/src/article_discovery/models.py
+++ b/src/article_discovery/models.py
@@ -1,6 +1,24 @@
 """Article discovery models."""
+from dataclasses import dataclass
 from datetime import datetime
 from pydantic import BaseModel, field_validator, ConfigDict
+
+
+@dataclass
+class RssFeedConfig:
+    """
+    Configuration for a single RSS feed.
+
+    Used to configure RSS feed discoverers with multiple feeds,
+    where each feed maps to a different section.
+
+    Attributes:
+        url: RSS feed URL
+        section: Section name to assign to discovered articles from this feed
+    """
+
+    url: str
+    section: str
 
 
 class DiscoveredArticle(BaseModel):

--- a/tests/article_discovery/discoverers/test_gleaner_rss_discoverer.py
+++ b/tests/article_discovery/discoverers/test_gleaner_rss_discoverer.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 
 from src.article_discovery.discoverers.gleaner_rss_discoverer import GleanerRssFeedDiscoverer
-from src.article_discovery.models import DiscoveredArticle
+from src.article_discovery.models import DiscoveredArticle, RssFeedConfig
 
 # Real RSS feed XML from Jamaica Gleaner (subset for testing)
 REAL_GLEANER_RSS_FEED = b'''<?xml version="1.0" encoding="utf-8"?>
@@ -53,6 +53,42 @@ REAL_GLEANER_RSS_FEED = b'''<?xml version="1.0" encoding="utf-8"?>
   </channel>
 </rss>'''
 
+# Real RSS feed XML from Jamaica Gleaner news section (subset for testing)
+REAL_GLEANER_NEWS_RSS_FEED = b'''<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0" xml:base="https://jamaica-gleaner.com/">
+  <channel>
+    <title>News</title>
+    <link>https://jamaica-gleaner.com/</link>
+    <description/>
+    <language>en</language>
+
+    <item>
+  <title>Diaspora plans Christmas support for children</title>
+  <link>https://jamaica-gleaner.com/article/news/20251216/diaspora-plans-christmas-support-children</link>
+  <description>A consortium of diaspora leaders is preparing a major Christmas initiative for children in western Jamaica affected by Hurricane Melissa. The effort will include a toy drive for children who lost belongings, holiday meals and gatherings to restore...</description>
+  <pubDate>Tue, 16 Dec 2025 00:08:12 -0500</pubDate>
+    <dc:creator>Lester Hinds/Gleaner Writer</dc:creator>
+    <guid isPermaLink="true">https://jamaica-gleaner.com/article/news/20251216/diaspora-plans-christmas-support-children</guid>
+    </item>
+<item>
+  <title>Justice of the peace arrested in St Andrew for allegedly soliciting cash to sign documents</title>
+  <link>https://jamaica-gleaner.com/article/news/20251216/justice-peace-arrested-st-andrew-allegedly-soliciting-cash-sign-documents</link>
+  <description>A justice of the peace (JP) was arrested in St Andrew on Monday during a sting operation after they allegedly collected money to sign an official document, law-enforcement sources have confirmed. The JP was arrested for breaches of the Corruption...</description>
+  <pubDate>Tue, 16 Dec 2025 10:59:33 -0500</pubDate>
+    <dc:creator/>
+    <guid isPermaLink="true">https://jamaica-gleaner.com/article/news/20251216/justice-peace-arrested-st-andrew-allegedly-soliciting-cash-sign-documents</guid>
+    </item>
+<item>
+  <title>Driver fined $450,000 or 12 months in prison for friend's death in Portmore crash</title>
+  <link>https://jamaica-gleaner.com/article/news/20251216/driver-fined-450000-or-12-months-prison-friends-death-portmore-crash</link>
+  <description>A St Catherine motorist who pleaded guilty to causing the death of his friend in a motor vehicle crash in 2021 has been fined $450,000 or 12 months in prison. His driver's licence has been suspended for one year. The sentence was handed down on...</description>
+  <pubDate>Tue, 16 Dec 2025 08:49:03 -0500</pubDate>
+    <dc:creator/>
+    <guid isPermaLink="true">https://jamaica-gleaner.com/article/news/20251216/driver-fined-450000-or-12-months-prison-friends-death-portmore-crash</guid>
+    </item>
+
+  </channel>
+</rss>'''
 
 class TestGleanerRssFeedDiscovererHappyPath:
     """Test successful RSS discovery scenarios."""
@@ -65,7 +101,8 @@ class TestGleanerRssFeedDiscovererHappyPath:
         mock_response.content = REAL_GLEANER_RSS_FEED
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer()
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
         news_source_id = 1
 
         # When: Discovering articles
@@ -84,7 +121,8 @@ class TestGleanerRssFeedDiscovererHappyPath:
         mock_response.content = REAL_GLEANER_RSS_FEED
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer(section="custom-section")
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="custom-section")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When: Discovering articles
         articles = await discoverer.discover(news_source_id=1)
@@ -101,7 +139,8 @@ class TestGleanerRssFeedDiscovererHappyPath:
         mock_response.content = REAL_GLEANER_RSS_FEED
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer()
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When: Discovering articles
         articles = await discoverer.discover(news_source_id=1)
@@ -122,7 +161,8 @@ class TestGleanerRssFeedDiscovererHappyPath:
         mock_response.content = REAL_GLEANER_RSS_FEED
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer()
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When: Discovering articles
         articles = await discoverer.discover(news_source_id=1)
@@ -142,7 +182,8 @@ class TestGleanerRssFeedDiscovererHappyPath:
         mock_response.content = REAL_GLEANER_RSS_FEED
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer()
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When: Discovering articles
         articles = await discoverer.discover(news_source_id=1)
@@ -162,7 +203,8 @@ class TestGleanerRssFeedDiscovererHappyPath:
         mock_response.content = REAL_GLEANER_RSS_FEED
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer()
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When: Discovering articles
         articles = await discoverer.discover(news_source_id=1)
@@ -203,7 +245,8 @@ class TestGleanerRssFeedDiscovererHappyPath:
         mock_response.content = duplicate_feed
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer()
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When: Discovering articles
         articles = await discoverer.discover(news_source_id=1)
@@ -221,7 +264,8 @@ class TestGleanerRssFeedDiscovererValidationErrors:
     @pytest.mark.asyncio
     async def test_discover_raises_error_for_zero_news_source_id(self):
         # Given: Invalid news source ID (zero)
-        discoverer = GleanerRssFeedDiscoverer()
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When/Then: Raises ValueError
         with pytest.raises(ValueError, match="Invalid news_source_id"):
@@ -230,7 +274,8 @@ class TestGleanerRssFeedDiscovererValidationErrors:
     @pytest.mark.asyncio
     async def test_discover_raises_error_for_negative_news_source_id(self):
         # Given: Invalid news source ID (negative)
-        discoverer = GleanerRssFeedDiscoverer()
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When/Then: Raises ValueError
         with pytest.raises(ValueError, match="Invalid news_source_id"):
@@ -241,17 +286,23 @@ class TestGleanerRssFeedDiscovererNetworkErrors:
     """Test network error handling and retry logic."""
 
     @pytest.mark.asyncio
-    async def test_discover_raises_error_for_unreachable_feed(self):
+    async def test_discover_returns_empty_list_for_unreachable_feed(self):
         # Given: Invalid feed URL (no mock, will actually fail)
+        feed_configs = [RssFeedConfig(
+            url="https://invalid-url-that-does-not-exist.test",
+            section="lead-stories"
+        )]
         discoverer = GleanerRssFeedDiscoverer(
-            feed_url="https://invalid-url-that-does-not-exist.test",
+            feed_configs=feed_configs,
             max_retries=2,  # Fewer retries for faster test
             base_backoff=0.1  # Shorter backoff for faster test
         )
 
-        # When/Then: Raises RuntimeError after retries
-        with pytest.raises(RuntimeError, match="Failed to fetch RSS feed after 2 attempts"):
-            await discoverer.discover(news_source_id=1)
+        # When: Discovering articles from unreachable feed
+        articles = await discoverer.discover(news_source_id=1)
+
+        # Then: Returns empty list (fail-soft behavior)
+        assert articles == []
 
     @pytest.mark.asyncio
     @patch('requests.get')
@@ -266,8 +317,9 @@ class TestGleanerRssFeedDiscovererNetworkErrors:
             mock_response
         ]
 
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
         discoverer = GleanerRssFeedDiscoverer(
-            feed_url="https://example.com/feed.xml",
+            feed_configs=feed_configs,
             max_retries=3,
             base_backoff=0.01  # Very short for testing
         )
@@ -285,17 +337,18 @@ class TestGleanerRssFeedDiscovererNetworkErrors:
         # Given: Network always fails
         mock_get.side_effect = requests.RequestException("Network error")
 
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
         discoverer = GleanerRssFeedDiscoverer(
-            feed_url="https://example.com/feed.xml",
+            feed_configs=feed_configs,
             max_retries=3,
             base_backoff=0.01  # Very short for testing
         )
 
-        # When/Then: Raises error after max retries
-        with pytest.raises(RuntimeError, match="Failed to fetch RSS feed after 3 attempts"):
-            await discoverer.discover(news_source_id=1)
+        # When: Attempting to discover articles
+        articles = await discoverer.discover(news_source_id=1)
 
-        # Verify it tried exactly max_retries times
+        # Then: Returns empty list (fail-soft) and retries exactly max_retries times
+        assert articles == []
         assert mock_get.call_count == 3
 
 
@@ -315,7 +368,8 @@ class TestGleanerRssFeedDiscovererEdgeCases:
         </rss>'''
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer(feed_url="https://example.com/feed.xml")
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When: Discovering articles
         articles = await discoverer.discover(news_source_id=1)
@@ -345,7 +399,8 @@ class TestGleanerRssFeedDiscovererEdgeCases:
         </rss>'''
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer(feed_url="https://example.com/feed.xml")
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When: Discovering articles
         articles = await discoverer.discover(news_source_id=1)
@@ -373,7 +428,8 @@ class TestGleanerRssFeedDiscovererEdgeCases:
         </rss>'''
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer(feed_url="https://example.com/feed.xml")
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When: Discovering articles
         articles = await discoverer.discover(news_source_id=1)
@@ -400,7 +456,8 @@ class TestGleanerRssFeedDiscovererEdgeCases:
         </rss>'''
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer(feed_url="https://example.com/feed.xml")
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When: Discovering articles
         articles = await discoverer.discover(news_source_id=1)
@@ -412,17 +469,20 @@ class TestGleanerRssFeedDiscovererEdgeCases:
 
     @pytest.mark.asyncio
     @patch('requests.get')
-    async def test_discover_raises_error_for_invalid_xml(self, mock_get):
+    async def test_discover_returns_empty_list_for_invalid_xml(self, mock_get):
         # Given: Invalid XML (not well-formed)
         mock_response = Mock()
         mock_response.content = b'<rss><channel><item>broken xml'
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer(feed_url="https://example.com/feed.xml")
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
-        # When/Then: Raises RuntimeError for invalid feed format
-        with pytest.raises(RuntimeError, match="Invalid RSS feed format"):
-            await discoverer.discover(news_source_id=1)
+        # When: Attempting to discover articles from invalid XML
+        articles = await discoverer.discover(news_source_id=1)
+
+        # Then: Returns empty list (fail-soft behavior)
+        assert articles == []
 
     @pytest.mark.asyncio
     @patch('requests.get')
@@ -432,7 +492,8 @@ class TestGleanerRssFeedDiscovererEdgeCases:
         mock_response.content = REAL_GLEANER_RSS_FEED
         mock_get.return_value = mock_response
 
-        discoverer = GleanerRssFeedDiscoverer()
+        feed_configs = [RssFeedConfig(url="https://example.com/feed.xml", section="lead-stories")]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
 
         # When: Discovering articles
         articles = await discoverer.discover(news_source_id=1)
@@ -441,3 +502,92 @@ class TestGleanerRssFeedDiscovererEdgeCases:
         # (Fourth article has empty dc:creator)
         assert len(articles) == 4
         assert articles[3].title == "Jamaican man dies after being struck by moped driver in Queens"  # Trailing space stripped
+
+
+class TestGleanerRssFeedDiscovererMultiFeed:
+    """Test multi-feed support."""
+
+    @pytest.mark.asyncio
+    @patch('requests.get')
+    async def test_discover_combines_articles_from_multiple_feeds(self, mock_get):
+        # Given: Two feeds (lead-stories and news) with different articles
+        mock_response_lead = Mock()
+        mock_response_lead.content = REAL_GLEANER_RSS_FEED  # Lead stories feed (4 articles)
+        mock_response_news = Mock()
+        mock_response_news.content = REAL_GLEANER_NEWS_RSS_FEED  # News feed (3 articles)
+        mock_get.side_effect = [mock_response_lead, mock_response_news]
+
+        feed_configs = [
+            RssFeedConfig(url="https://jamaica-gleaner.com/feed/rss.xml", section="lead-stories"),
+            RssFeedConfig(url="https://jamaica-gleaner.com/feed/news.xml", section="news")
+        ]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
+
+        # When: Discovering articles
+        articles = await discoverer.discover(news_source_id=1)
+
+        # Then: Returns articles from both feeds (4 + 3 = 7 total)
+        assert len(articles) == 7
+        
+        # Verify articles from lead-stories feed
+        lead_stories_articles = [a for a in articles if a.section == "lead-stories"]
+        assert len(lead_stories_articles) == 4
+        assert any("knockout-blow" in a.url for a in lead_stories_articles)
+        
+        # Verify articles from news feed
+        news_articles = [a for a in articles if a.section == "news"]
+        assert len(news_articles) == 3
+        assert any("diaspora-plans-christmas-support" in a.url for a in news_articles)
+
+    @pytest.mark.asyncio
+    @patch('requests.get')
+    async def test_discover_deduplicates_across_feeds(self, mock_get):
+        # Given: Two feeds with the same articles (simulate overlap)
+        mock_response = Mock()
+        mock_response.content = REAL_GLEANER_RSS_FEED  # Same feed content for both
+        mock_get.side_effect = [mock_response, mock_response]
+
+        feed_configs = [
+            RssFeedConfig(url="https://jamaica-gleaner.com/feed/rss.xml", section="lead-stories"),
+            RssFeedConfig(url="https://jamaica-gleaner.com/feed/news.xml", section="news")
+        ]
+        discoverer = GleanerRssFeedDiscoverer(feed_configs=feed_configs)
+
+        # When: Discovering articles
+        articles = await discoverer.discover(news_source_id=1)
+
+        # Then: Returns only unique articles (4, not 8)
+        assert len(articles) == 4
+        # Verify all URLs are unique
+        urls = [a.url for a in articles]
+        assert len(urls) == len(set(urls))
+
+    @pytest.mark.asyncio
+    @patch('requests.get')
+    async def test_discover_continues_when_one_feed_fails(self, mock_get):
+        # Given: First feed fails, second succeeds
+        mock_response_news = Mock()
+        mock_response_news.content = REAL_GLEANER_NEWS_RSS_FEED
+
+        mock_get.side_effect = [
+            requests.RequestException("Network error"),  # Lead stories feed fails
+            mock_response_news  # News feed succeeds
+        ]
+
+        feed_configs = [
+            RssFeedConfig(url="https://jamaica-gleaner.com/feed/rss.xml", section="lead-stories"),
+            RssFeedConfig(url="https://jamaica-gleaner.com/feed/news.xml", section="news")
+        ]
+        discoverer = GleanerRssFeedDiscoverer(
+            feed_configs=feed_configs,
+            max_retries=1,  # Minimize retries for faster test
+            base_backoff=0.01
+        )
+
+        # When: Discovering articles
+        articles = await discoverer.discover(news_source_id=1)
+
+        # Then: Returns articles from successful feed only (fail-soft behavior)
+        assert len(articles) == 3
+        assert all(a.section == "news" for a in articles)
+        assert any("diaspora-plans-christmas-support" in a.url for a in articles)


### PR DESCRIPTION
Implemented comprehensive multi-feed RSS architecture that enables discovering articles from multiple RSS feeds simultaneously. The system now supports configuring different feeds for different sections (e.g., lead-stories, news) with intelligent cross-feed deduplication and fail-soft error handling.

Changes:
- Created `RssFeedConfig` dataclass in `src/article_discovery/models.py` with `url` and `section` fields for feed-to-section mapping
- Refactored `GleanerRssFeedDiscoverer` constructor to require `feed_configs: list[RssFeedConfig]` parameter (breaking change from single feed URL)
- Extracted `_discover_from_feed()` method for processing individual feeds with separate error handling
- Updated `discover()` to loop through all configured feeds with fail-soft error handling (continues if one feed fails)
- Made helper methods functional by accepting parameters instead of using instance variables:
  - `_fetch_feed_with_retry()` now accepts `feed_url` parameter
  - `_parse_rss_entry()` and `_parse_all_entries()` now accept `section` parameter
  - `_log_skipped_entry()` now accepts `feed_url` parameter for better error context
- Implemented critical cross-feed deduplication: articles are deduplicated by URL AFTER merging all feeds (not per-feed)
- Updated validation script `scripts/validate_rss_discovery.py` to demonstrate multi-feed usage with both lead-stories and news feeds
- Added per-section statistics to validation script output for better visibility
- Updated all 18 existing tests for new constructor signature in `tests/article_discovery/discoverers/test_gleaner_rss_discoverer.py`
- Added 3 new multi-feed integration tests using real Jamaica Gleaner RSS content:
  - Test combining articles from multiple feeds
  - Test cross-feed deduplication (same article in both feeds)
  - Test fail-soft error handling (one feed fails, other succeeds)
- Added comprehensive "Article Discovery System" section to `CLAUDE.md` with architecture, features, usage examples, and design notes

Why:
This multi-feed architecture provides critical flexibility for discovering articles from multiple news sources or sections without duplicating discoverer instances. The fail-soft error handling ensures that a failure in one feed doesn't prevent discovery from other feeds, improving system resilience. Cross-feed deduplication is essential because news sites often publish the same article in multiple feeds (e.g., breaking news appears in both lead-stories and news sections). Sequential feed processing respects rate limits while the functional helper methods improve testability and maintainability. This design establishes a pattern for future multi-source discovery implementations and ensures the system can scale to additional feeds without architectural changes.

Issue: #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)