### PR TITLE
feat(classification): update corruption classifier to ignore editorials

### DIFF
--- a/src/article_classification/agents/corruption_agent.py
+++ b/src/article_classification/agents/corruption_agent.py
@@ -45,6 +45,29 @@ or related issues that would be relevant to government transparency tracking.
 - Sports, entertainment, weather
 - Political campaign rhetoric without specific allegations
 - Traffic accidents, robberies, general news
+- **Letters to the Editor and reader submissions** (look for salutations like "THE EDITOR, Sir:", "Dear Editor", email signatures)
+- **Editorials and opinion pieces** (look for markers like "[EDITORIAL]", "OPINION" section headers, first-person commentary)
+
+**Detecting Editorial/Opinion Content (EXCLUDE THESE):**
+
+Look for these markers indicating the article is NOT investigative journalism:
+1. **Letter to the Editor markers:**
+   - Salutations: "THE EDITOR, Sir:", "Dear Editor", "Dear Sir"
+   - Email signatures at end (e.g., "john@example.com")
+   - Letter markers: "[LETTER OF THE DAY]", "Letters to the Editor"
+
+2. **Editorial markers:**
+   - Section headers: "[EDITORIAL]", "OPINION", "COMMENTARY"
+   - Generic bylines: "The Editorial Board", "The Gleaner [EDITORIAL]"
+   - Opinion page context
+
+3. **Reader opinion patterns:**
+   - First-person reader commentary about news events
+   - Signed with reader name and contact info
+
+If you detect any of these markers, classify as **NOT RELEVANT** with low confidence (0.0-0.3),
+even if the content discusses corruption topics. We only want investigative news articles,
+not reader opinions or editorial commentary.
 
 **Output Requirements:**
 

--- a/tests/article_classification/classifiers/test_corruption_classifier_integration.py
+++ b/tests/article_classification/classifiers/test_corruption_classifier_integration.py
@@ -41,6 +41,39 @@ def ocg_investigation_article() -> ClassificationInput:
     )
 
 
+@pytest.fixture
+def letter_to_editor_article() -> ClassificationInput:
+    """Reader letter mentioning corruption - should be NOT RELEVANT."""
+    return ClassificationInput(
+        url="https://gleaner.newspaperarchive.com/kingston-gleaner/2019-04-05/page-10/",
+        title="Reid's resignation disappointing and demoralising",
+        section="letters",
+        full_text="""
+        THE EDITOR, Sir:
+        "Mommy, Education Minister Ruel Reid has been fired because of
+        nepotism. It is when you hire family and friends without qualification."
+        (11-year-old boy, St Elizabeth)
+
+        "Reid was sacked as minister over allegations of corruption and
+        misuse of public funds in the ministry." (The Gleaner – March 21, 2019)
+
+        The names of many outstanding Munronians, including Ruel Reid, are
+        on the school's honours board. The little boy and other new students
+        are likely to learn that it is the same Ruel Reid that was fired because of
+        allegations of impropriety in the education ministry.
+
+        Reid's reputation has been damaged. Even if the investigations
+        and due process should clear him of any wrongdoing, doubts will
+        still linger for many because he has already been tried in the court of
+        public opinion.
+
+        DAIVE R FACEY
+        DR.Facey@gmail.com
+        """,
+        published_date=datetime(2019, 4, 5, tzinfo=timezone.utc),
+    )
+
+
 class TestCorruptionClassifierIntegration:
     """Integration tests that make actual LLM API calls."""
 
@@ -64,3 +97,25 @@ class TestCorruptionClassifierIntegration:
         # The agent may return normalized entities (e.g., "ocg") or raw entities (e.g., "OCG")
         normalized_entities = [entity.lower() for entity in result.key_entities]
         assert any("ocg" in entity or "contractor" in entity for entity in normalized_entities)
+
+    @pytest.mark.external
+    @pytest.mark.integration
+    async def test_excludes_letter_to_editor_despite_corruption_mention(
+        self, classifier: CorruptionClassifier, letter_to_editor_article: ClassificationInput
+    ):
+        # Given: Letter to the editor that mentions corruption/nepotism
+        # When: Classifying the article
+        result: ClassificationResult = await classifier.classify(letter_to_editor_article)
+
+        # Then: Article is classified as NOT RELEVANT (editorial content)
+        assert isinstance(result, ClassificationResult)
+        assert result.is_relevant is False
+        assert result.confidence <= 0.3  # Low confidence for editorial content
+        assert result.classifier_type == ClassifierType.CORRUPTION
+        assert result.model_name == "gpt-5-nano"
+        assert len(result.reasoning) > 0
+        # Reasoning should mention it's a letter to the editor
+        assert any(
+            marker in result.reasoning.lower()
+            for marker in ["letter", "editor", "opinion", "editorial", "reader"]
+        )


### PR DESCRIPTION
Why:
I want the accuracy of the system to be high.
Only focus on journalistic reports

Issues:
closes #77