### PR TITLE
fix: add reconnection logic for db pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,11 @@ POSTGRES_DB=jaacountable_db
 POSTGRES_PORT=5432
 
 # Database Connection Pool
-DB_POOL_MIN_SIZE=1  # Minimum connections in pool (keep low for free-tier DBs)
-DB_POOL_MAX_SIZE=5  # Maximum connections in pool (Supabase free tier: ~60 total)
+DB_POOL_MIN_SIZE=1          # Minimum connections in pool (keep low for free-tier DBs)
+DB_POOL_MAX_SIZE=5          # Maximum connections in pool (Supabase free tier: ~60 total)
+DB_POOL_CONNECT_TIMEOUT=10  # Seconds to wait for each individual connection attempt
+DB_POOL_MAX_RETRIES=5       # Max attempts to create the pool before giving up (handles cold starts)
+DB_POOL_RETRY_BASE_BACKOFF=2.0  # Base for exponential backoff between retries (2^attempt seconds)
 
 # OpenAI API Key (for LiteLLM classification models)
 OPENAI_API_KEY=sk-abc123

--- a/config/database.py
+++ b/config/database.py
@@ -1,11 +1,18 @@
 """Database configuration and connection pool management."""
 import asyncio
 import os
+from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
-from typing import Optional
+from typing import Optional, TypeVar
 from urllib.parse import urlparse, urlunparse
 import asyncpg
 from loguru import logger
+
+_POOL_CONNECT_TIMEOUT = float(os.getenv("DB_POOL_CONNECT_TIMEOUT", "10.0"))
+_POOL_MAX_RETRIES = int(os.getenv("DB_POOL_MAX_RETRIES", "5"))
+_POOL_RETRY_BASE_BACKOFF = float(os.getenv("DB_POOL_RETRY_BASE_BACKOFF", "2.0"))
+
+T = TypeVar("T")
 
 
 class DatabaseConfig:
@@ -87,32 +94,64 @@ class DatabaseConfig:
         min_size: int = int(os.getenv("DB_POOL_MIN_SIZE", "1")),
         max_size: int = int(os.getenv("DB_POOL_MAX_SIZE", "5")),
         command_timeout: float = 60.0,
+        connect_timeout: float = _POOL_CONNECT_TIMEOUT,
+        max_retries: int = _POOL_MAX_RETRIES,
+        base_backoff: float = _POOL_RETRY_BASE_BACKOFF,
     ) -> asyncpg.Pool:
         """
         Create and return a connection pool.
 
+        Retries with exponential backoff on connection failures (e.g. app container
+        network not yet ready after cold start / hibernation wake-up).
+
         Args:
             min_size: Minimum number of connections in the pool
             max_size: Maximum number of connections in the pool
-            command_timeout: Timeout for commands in seconds
+            command_timeout: Timeout for individual queries in seconds
+            connect_timeout: Timeout for establishing each connection attempt in seconds
+            max_retries: Maximum number of connection attempts before giving up
+            base_backoff: Base for exponential backoff between attempts (base^attempt seconds)
 
         Returns:
             asyncpg.Pool: Connection pool instance
         """
         async with self._pool_lock:
             if self._pool is None:
-                self._pool = await asyncpg.create_pool(
-                    self.get_asyncpg_url(),
-                    min_size=min_size,
-                    max_size=max_size,
-                    command_timeout=command_timeout,
+                attempt_count = 0
+
+                # retry_with_backoff requires a function as an argument
+                # we create the pool inside a function to accomplish this.
+                async def _create() -> asyncpg.Pool:
+                    nonlocal attempt_count
+                    attempt_count += 1
+                    return await asyncpg.create_pool(
+                        self.get_asyncpg_url(),
+                        min_size=min_size,
+                        max_size=max_size,
+                        command_timeout=command_timeout,
+                        timeout=connect_timeout,
+                    )
+
+                # Startup Failure: asyncpg Pool Timeout due to Cancelled Connection
+                # What's wrong: Application startup fails due to asyncpg connection pool creation timeout.
+                # Fix: Add retry logic while attempts to connect to the database
+                # Context: https://github.com/AshciR/jaacountable-backend/issues/188
+                self._pool = await retry_with_backoff(
+                    _create,
+                    retry_on=(OSError, asyncpg.PostgresConnectionError),
+                    max_retries=max_retries,
+                    base_backoff=base_backoff,
+                    label="Database pool creation",
                 )
-            logger.info(
-                "Database pool created: url={}, min_size={}, max_size={}",
-                self.mask_url(self.get_asyncpg_url()),
-                min_size,
-                max_size,
-            )
+
+                attempt_note = f" (after {attempt_count} attempts)" if attempt_count > 1 else ""
+                logger.info(
+                    "Database pool created{}: url={}, min_size={}, max_size={}",
+                    attempt_note,
+                    self.mask_url(self.get_asyncpg_url()),
+                    min_size,
+                    max_size,
+                )
             return self._pool
 
     async def close_pool(self) -> None:
@@ -175,6 +214,53 @@ class DatabaseConfig:
             "max_size": self._pool.get_max_size(),
         }
 
+
+async def retry_with_backoff(
+    fn: Callable[[], Awaitable[T]],
+    *,
+    retry_on: tuple[type[Exception], ...],
+    max_retries: int,
+    base_backoff: float,
+    label: str = "operation",
+) -> T:
+    """
+    Execute an async callable with exponential backoff retries.
+
+    Args:
+        fn: Async callable to execute (no arguments; use a lambda or partial to bind args).
+        retry_on: Tuple of exception types that should trigger a retry.
+        max_retries: Maximum number of attempts before re-raising.
+        base_backoff: Base for exponential delay — attempt N waits base^N seconds.
+        label: Human-readable name shown in log messages.
+
+    Returns:
+        The return value of fn on success.
+
+    Raises:
+        The last exception raised by fn if all attempts fail.
+    """
+    for attempt in range(1, max_retries + 1):
+        try:
+            return await fn()
+        except retry_on as e:
+            if attempt < max_retries:
+                backoff_time = base_backoff ** attempt
+                logger.warning(
+                    "{} failed (attempt {}/{}) : {}. Retrying in {:.1f}s...",
+                    label,
+                    attempt,
+                    max_retries,
+                    e,
+                    backoff_time,
+                )
+                await asyncio.sleep(backoff_time)
+            else:
+                logger.error(
+                    "{} failed after {} attempts. Giving up.",
+                    label,
+                    max_retries,
+                )
+                raise
 
 # Global database configuration instance
 db_config = DatabaseConfig()

--- a/tests/config/test_database_config.py
+++ b/tests/config/test_database_config.py
@@ -1,8 +1,12 @@
-"""Unit tests for DatabaseConfig.mask_url()."""
+"""Unit tests for DatabaseConfig.mask_url() and retry_with_backoff()."""
 
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import asyncpg
 import pytest
 
-from config.database import DatabaseConfig
+from config.database import DatabaseConfig, retry_with_backoff
 
 
 class TestMaskUrl:
@@ -111,3 +115,108 @@ class TestMaskUrl:
         assert "****user" in result
         assert "****pass" in result
         assert "://user:" not in result
+
+
+class TestRetryWithBackoff:
+    """DatabaseConfig.create_pool() retries on transient failures with exponential backoff."""
+
+    async def test_succeeds_on_first_attempt(self, test_database_url: str):
+        # Given: a DatabaseConfig pointing at the real test database
+        asyncpg_url = test_database_url.replace("postgresql+psycopg2://", "postgresql+asyncpg://")
+        db_config = DatabaseConfig(database_url=asyncpg_url)
+
+        # When: create_pool is called
+        try:
+            pool = await db_config.create_pool(min_size=1, max_size=1)
+
+            # Then: pool is created with the exact requested size
+            assert pool is not None
+            assert pool.get_size() == 1
+        finally:
+            await db_config.close_pool()
+
+    async def test_retries_then_succeeds(self, test_database_url: str):
+        # Given: a DatabaseConfig pointing at the real test database,
+        #        where asyncpg.create_pool fails on the first attempt
+        asyncpg_url = test_database_url.replace("postgresql+psycopg2://", "postgresql+asyncpg://")
+        db_config = DatabaseConfig(database_url=asyncpg_url)
+        call_count = 0
+        original_create_pool = asyncpg.create_pool
+
+        async def flaky_create_pool(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise OSError("simulated network blip on container wake-up")
+            return await original_create_pool(*args, **kwargs)
+
+        # When: create_pool is called (sleep patched to keep test fast)
+        try:
+            with patch("asyncpg.create_pool", side_effect=flaky_create_pool):
+                with patch("config.database.asyncio.sleep", new_callable=AsyncMock):
+                    pool = await db_config.create_pool(min_size=1, max_size=1, max_retries=3)
+
+            # Then: pool is created after exactly 2 attempts
+            assert pool is not None
+            assert pool.get_size() == 1
+            assert call_count == 2
+        finally:
+            await db_config.close_pool()
+
+    async def test_raises_after_all_attempts_exhausted(self):
+        # Given: a DatabaseConfig pointing at a port nothing is listening on
+        db_config = DatabaseConfig(database_url="postgresql+asyncpg://user:password@localhost:1/db")
+
+        # When / Then: all retries fail and the exception propagates
+        with pytest.raises((OSError, asyncpg.PostgresConnectionError)):
+            await db_config.create_pool(
+                min_size=1,
+                max_size=1,
+                connect_timeout=1.0,
+                max_retries=2,
+                base_backoff=0.1,
+            )
+
+    async def test_does_not_retry_unregistered_exception(self, test_database_url: str):
+        # Given: a DatabaseConfig where asyncpg.create_pool raises an unexpected error
+        asyncpg_url = test_database_url.replace("postgresql+psycopg2://", "postgresql+asyncpg://")
+        db_config = DatabaseConfig(database_url=asyncpg_url)
+        call_count = 0
+
+        async def broken_create_pool(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("unexpected programming error")
+
+        # When / Then: ValueError propagates immediately without retry
+        try:
+            with patch("asyncpg.create_pool", side_effect=broken_create_pool):
+                with pytest.raises(ValueError, match="unexpected programming error"):
+                    await db_config.create_pool(min_size=1, max_size=1, max_retries=3)
+
+            # And: only one attempt was made
+            assert call_count == 1
+        finally:
+            await db_config.close_pool()
+
+    async def test_max_retries_one_is_single_attempt(self, test_database_url: str):
+        # Given: a DatabaseConfig where asyncpg.create_pool always fails
+        asyncpg_url = test_database_url.replace("postgresql+psycopg2://", "postgresql+asyncpg://")
+        db_config = DatabaseConfig(database_url=asyncpg_url)
+        call_count = 0
+
+        async def always_fails(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise OSError("gone")
+
+        # When: create_pool is called with max_retries=1
+        try:
+            with patch("asyncpg.create_pool", side_effect=always_fails):
+                with pytest.raises(OSError):
+                    await db_config.create_pool(min_size=1, max_size=1, max_retries=1)
+
+            # Then: only one attempt, no further retries
+            assert call_count == 1
+        finally:
+            await db_config.close_pool()


### PR DESCRIPTION
Sentry:
Traceback (most recent call last):
Issue ID: 7367089920
Project: jaccountable-backend
Date: 3/26/2026, 6:54:23 PM

Issue Summary
Startup Failure: asyncpg Pool Timeout due to Cancelled Connection What's wrong: Application startup fails due to asyncpg connection pool creation timeout. In the trace: Startup lifespan context in FastAPI is blocked waiting for database pool initialization. Possible cause: The asyncpg connection attempt was CancelledError during SSL setup, possibly due to network instability or configuration mismatch.

Tags
environment: staging
level: error
logger: uvicorn.error
runtime: CPython 3.12.13
runtime.name: CPython
server_name: srv-d729kikg9agc73935mng-hibernate-5774c6c94b-zzcdk https://jaccountable.sentry.io/issues/7367089920/?environment=staging&project=4511085771423744&query=is%3Aunresolved&referrer=issue-stream

Issues:
fixes #188