### PR TITLE
bug: some Gleaner Articles are duplicated during classification

### DIFF
--- a/src/article_discovery/utils.py
+++ b/src/article_discovery/utils.py
@@ -1,8 +1,31 @@
 """Utility functions for article discovery."""
 
+from urllib.parse import unquote, urlparse, urlunparse
+
 from loguru import logger
 
 from src.article_discovery.models import DiscoveredArticle
+
+
+def normalize_url(url: str) -> str:
+    """
+    Normalize a URL to its canonical form.
+
+    - Percent-decodes encoded characters (e.g. %2e → .)
+    - Strips the /index.php/ front-controller prefix if present
+
+    Args:
+        url: Raw URL string (possibly percent-encoded or with index.php prefix)
+
+    Returns:
+        Canonical URL string
+    """
+    decoded = unquote(url)
+    parsed = urlparse(decoded)
+    path = parsed.path
+    if path.startswith("/index.php/"):
+        path = path[len("/index.php"):]
+    return urlunparse(parsed._replace(path=path))
 
 
 def deduplicate_discovered_articles(
@@ -11,6 +34,10 @@ def deduplicate_discovered_articles(
     """
     Deduplicate articles by URL, keeping first occurrence.
 
+    URLs are normalized before comparison so that percent-encoded variants
+    (e.g. index%2ephp) and /index.php/ prefixes are treated as the same article.
+    The stored article always has the canonical (normalized) URL.
+
     This is a standalone helper function for deduplicating articles
     across multiple discoverers (e.g., when running parallel workers).
 
@@ -18,7 +45,7 @@ def deduplicate_discovered_articles(
         articles: List of articles (potentially with duplicates)
 
     Returns:
-        Deduplicated list (first occurrence kept for each URL)
+        Deduplicated list (first occurrence kept for each URL, URL normalized)
 
     Example:
         # Combine results from multiple workers
@@ -33,9 +60,10 @@ def deduplicate_discovered_articles(
     deduplicated: list[DiscoveredArticle] = []
 
     for article in articles:
-        if article.url not in seen_urls:
-            seen_urls.add(article.url)
-            deduplicated.append(article)
+        canonical_url = normalize_url(article.url)
+        if canonical_url not in seen_urls:
+            seen_urls.add(canonical_url)
+            deduplicated.append(article.model_copy(update={"url": canonical_url}))
         else:
             logger.debug(f"Duplicate URL found, skipping: {article.url}")
 

--- a/tests/article_discovery/test_utils.py
+++ b/tests/article_discovery/test_utils.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 import pytest
 
 from src.article_discovery.models import DiscoveredArticle
-from src.article_discovery.utils import deduplicate_discovered_articles
+from src.article_discovery.utils import deduplicate_discovered_articles, normalize_url
 
 
 class TestDeduplicateDiscoveredArticles:
@@ -116,3 +116,116 @@ class TestDeduplicateDiscoveredArticles:
         # Then
         assert len(deduplicated) == 5
         assert deduplicated == articles
+
+    @pytest.mark.asyncio
+    async def test_deduplicate_treats_percent_encoded_and_decoded_urls_as_same(self):
+        """
+        GIVEN two articles with URLs that differ only by percent-encoding (%2e vs .)
+        WHEN deduplicate_discovered_articles() is called
+        THEN it treats them as the same article, keeps only one, and stores the canonical URL
+        """
+        # Given — the real-world example from issue-213
+        encoded_url_article = DiscoveredArticle(
+            url="http://jamaica-gleaner.com/index%2ephp/article/news/20260409/ethics-committee-summon-gordon",
+            news_source_id=1,
+            section="lead-stories",
+            discovered_at=datetime.now(timezone.utc),
+        )
+        decoded_url_article = DiscoveredArticle(
+            url="http://jamaica-gleaner.com/article/news/20260409/ethics-committee-summon-gordon",
+            news_source_id=1,
+            section="lead-stories",
+            discovered_at=datetime.now(timezone.utc),
+        )
+
+        # When
+        deduplicated = deduplicate_discovered_articles(
+            [encoded_url_article, decoded_url_article]
+        )
+
+        # Then — one article, stored with canonical URL
+        assert len(deduplicated) == 1
+        assert deduplicated[0].url == (
+            "http://jamaica-gleaner.com/article/news/20260409/ethics-committee-summon-gordon"
+        )
+
+
+class TestNormalizeUrl:
+    """Test normalize_url() helper function."""
+
+    def test_normalize_url_decodes_percent_encoded_dot(self):
+        """
+        GIVEN a URL with %2e (percent-encoded dot)
+        WHEN normalize_url() is called
+        THEN it returns the URL with the dot decoded
+        """
+        # Given
+        url = "http://jamaica-gleaner.com/index%2ephp/article/news/20260409/some-article"
+
+        # When
+        result = normalize_url(url)
+
+        # Then
+        assert "%2e" not in result
+        assert "%2E" not in result
+
+    def test_normalize_url_strips_index_php_prefix(self):
+        """
+        GIVEN a URL with a /index.php/ path prefix
+        WHEN normalize_url() is called
+        THEN it strips the /index.php prefix
+        """
+        # Given
+        url = "http://jamaica-gleaner.com/index.php/article/news/20260409/some-article"
+
+        # When
+        result = normalize_url(url)
+
+        # Then
+        assert result == "http://jamaica-gleaner.com/article/news/20260409/some-article"
+
+    def test_normalize_url_strips_index_php_when_percent_encoded(self):
+        """
+        GIVEN a URL where index.php is percent-encoded as index%2ephp
+        WHEN normalize_url() is called
+        THEN it decodes and strips the /index.php prefix
+        """
+        # Given
+        url = "http://jamaica-gleaner.com/index%2ephp/article/news/20260409/ethics-committee-summon-gordon"
+
+        # When
+        result = normalize_url(url)
+
+        # Then
+        assert result == "http://jamaica-gleaner.com/article/news/20260409/ethics-committee-summon-gordon"
+
+    def test_normalize_url_leaves_clean_urls_unchanged(self):
+        """
+        GIVEN a URL that is already in canonical form
+        WHEN normalize_url() is called
+        THEN it returns the URL unchanged
+        """
+        # Given
+        url = "http://jamaica-gleaner.com/article/news/20260409/ethics-committee-summon-gordon"
+
+        # When
+        result = normalize_url(url)
+
+        # Then
+        assert result == url
+
+    def test_normalize_url_is_idempotent(self):
+        """
+        GIVEN a URL with percent-encoding and index.php prefix
+        WHEN normalize_url() is called twice
+        THEN both calls return the same result
+        """
+        # Given
+        url = "http://jamaica-gleaner.com/index%2ephp/article/news/20260409/some-article"
+
+        # When
+        first_call = normalize_url(url)
+        second_call = normalize_url(first_call)
+
+        # Then
+        assert first_call == second_call


### PR DESCRIPTION
Problem

  The same article can be discovered via two syntactically different URLs that both resolve to the same page:

  http://jamaica-gleaner.com/index%2ephp/article/news/20260409/ethics-committee-summon-gordon
  http://jamaica-gleaner.com/article/news/20260409/ethics-committee-summon-gordon

  %2e is a percent-encoded ., so the first URL decodes to an index.php/-prefixed path — a PHP front-controller pattern the web server rewrites to the same resource. Because deduplication and the DB unique
  constraint both key on the raw URL string, both pass through and the article gets stored twice.

  Solution

  1. Add normalize_url(url: str) -> str to src/article_discovery/utils.py
    - Percent-decode the URL (urllib.parse.unquote)
    - Strip the /index.php/ path prefix if present
    - Reassemble with urlunparse
  2. Update deduplicate_discovered_articles in utils.py to:
    - Use normalize_url as the deduplication key instead of the raw URL
    - Replace article.url with the normalized form via article.model_copy(update={"url": normalized}) so the DB always stores the canonical URL
  3. Remove the private _deduplicate_articles method from the three discoverers that each have their own copy, and inline a call to deduplicate_discovered_articles from utils instead:
    - src/article_discovery/discoverers/gleaner_rss_discoverer.py (line 326)
    - src/article_discovery/discoverers/gleaner_archive_discoverer.py (line 644)
    - src/article_discovery/discoverers/jamaica_observer_rss_discoverer.py (line 274)
    - Note: gleaner_archive_discoverer.py already imports deduplicate_discovered_articles; the other two will need the import added

Issues:
fixes #213