### PR TITLE
bug: HTML entities in article titles are not decoded

### DIFF
--- a/src/article_discovery/discoverers/gleaner_archive_discoverer.py
+++ b/src/article_discovery/discoverers/gleaner_archive_discoverer.py
@@ -11,6 +11,7 @@ from bs4 import BeautifulSoup
 from loguru import logger
 
 from src.article_discovery.models import DiscoveredArticle
+from src.article_discovery.utils import deduplicate_discovered_articles
 
 
 class RedirectError(Exception):
@@ -287,7 +288,7 @@ class GleanerArchiveDiscoverer:
                     continue
 
         # Deduplicate by URL
-        deduplicated = self._deduplicate_articles(all_articles)
+        deduplicated = deduplicate_discovered_articles(all_articles)
 
         logger.info(
             f"Archive discovery complete: {len(deduplicated)} unique articles discovered "
@@ -641,34 +642,4 @@ class GleanerArchiveDiscoverer:
             published_date=published_date,
         )
 
-    def _deduplicate_articles(
-        self, articles: list[DiscoveredArticle]
-    ) -> list[DiscoveredArticle]:
-        """
-        Remove duplicate articles by URL.
 
-        Keeps first occurrence of each unique URL.
-
-        Args:
-            articles: List of articles (may contain duplicates)
-
-        Returns:
-            List of articles with duplicates removed
-        """
-        seen_urls: set[str] = set()
-        deduplicated: list[DiscoveredArticle] = []
-
-        for article in articles:
-            if article.url not in seen_urls:
-                seen_urls.add(article.url)
-                deduplicated.append(article)
-            else:
-                logger.debug(f"Duplicate URL found, skipping: {article.url}")
-
-        if len(articles) != len(deduplicated):
-            logger.info(
-                f"Deduplicated {len(articles)} → {len(deduplicated)} articles "
-                f"({len(articles) - len(deduplicated)} duplicates removed)"
-            )
-
-        return deduplicated

--- a/src/article_discovery/discoverers/gleaner_rss_discoverer.py
+++ b/src/article_discovery/discoverers/gleaner_rss_discoverer.py
@@ -8,6 +8,7 @@ import httpx
 from loguru import logger
 
 from src.article_discovery.models import DiscoveredArticle, RssFeedConfig
+from src.article_discovery.utils import deduplicate_discovered_articles
 
 
 class GleanerRssFeedDiscoverer:
@@ -93,7 +94,7 @@ class GleanerRssFeedDiscoverer:
             return []
 
         # CRITICAL: Deduplicate across ALL feeds (not per-feed)
-        deduplicated_articles = self._deduplicate_articles(all_articles)
+        deduplicated_articles = deduplicate_discovered_articles(all_articles)
 
         duplicates_removed = len(all_articles) - len(deduplicated_articles)
         if duplicates_removed > 0:
@@ -323,26 +324,4 @@ class GleanerRssFeedDiscoverer:
             published_date=published_date,
         )
 
-    def _deduplicate_articles(
-        self, articles: list[DiscoveredArticle]
-    ) -> list[DiscoveredArticle]:
-        """
-        Remove duplicate URLs from article list.
 
-        Keeps the first occurrence of each URL.
-
-        Args:
-            articles: List of discovered articles
-
-        Returns:
-            Deduplicated list (first occurrence kept)
-        """
-        seen_urls = set()
-        unique_articles = []
-
-        for article in articles:
-            if article.url not in seen_urls:
-                seen_urls.add(article.url)
-                unique_articles.append(article)
-
-        return unique_articles

--- a/src/article_discovery/discoverers/jamaica_observer_rss_discoverer.py
+++ b/src/article_discovery/discoverers/jamaica_observer_rss_discoverer.py
@@ -8,6 +8,7 @@ import httpx
 from loguru import logger
 
 from src.article_discovery.models import DiscoveredArticle, RssFeedConfig
+from src.article_discovery.utils import deduplicate_discovered_articles
 
 
 class JamaicaObserverRssFeedDiscoverer:
@@ -89,7 +90,7 @@ class JamaicaObserverRssFeedDiscoverer:
             logger.warning("No articles discovered from any feed")
             return []
 
-        deduplicated_articles = self._deduplicate_articles(all_articles)
+        deduplicated_articles = deduplicate_discovered_articles(all_articles)
 
         duplicates_removed = len(all_articles) - len(deduplicated_articles)
         if duplicates_removed > 0:
@@ -270,20 +271,6 @@ class JamaicaObserverRssFeedDiscoverer:
             title=title,
             published_date=published_date,
         )
-
-    def _deduplicate_articles(
-        self, articles: list[DiscoveredArticle]
-    ) -> list[DiscoveredArticle]:
-        """Remove duplicate URLs, keeping the first occurrence."""
-        seen_urls = set()
-        unique_articles = []
-
-        for article in articles:
-            if article.url not in seen_urls:
-                seen_urls.add(article.url)
-                unique_articles.append(article)
-
-        return unique_articles
 
     def _log_skipped_entry(
         self, entry: Any, entry_num: int, total_entries: int, error: Exception, feed_url: str

--- a/src/article_extractor/models.py
+++ b/src/article_extractor/models.py
@@ -1,4 +1,5 @@
 """Article content models for extraction service."""
+import html
 from datetime import datetime
 from pydantic import BaseModel, field_validator, ConfigDict
 
@@ -25,7 +26,7 @@ class ExtractedArticleContent(BaseModel):
         """Validate that title is not empty."""
         if not v or not v.strip():
             raise ValueError("Title cannot be empty")
-        return v.strip()
+        return html.unescape(v.strip())
 
     @field_validator("full_text")
     @classmethod

--- a/tests/article_extractor/extractors/test_gleaner_archive_extractor.py
+++ b/tests/article_extractor/extractors/test_gleaner_archive_extractor.py
@@ -88,3 +88,37 @@ class TestGleanerArchiveExtractorHappyPath:
         # Date should be extracted from URL
         assert content.published_date is not None
         assert content.published_date == datetime(2021, 11, 7, tzinfo=timezone.utc)
+
+
+class TestGleanerArchiveExtractorHtmlEntityDecoding:
+    """HTML entity decoding in extracted titles."""
+
+    @patch("src.article_extractor.extractors.gleaner_archive_extractor.completion")
+    async def test_title_with_html_entities_from_llm_decoded(self, mock_completion):
+        # Given: LLM returns a headline containing HTML entities (possible when LLM output includes them)
+        mock_completion.side_effect = [
+            # First call: headline extraction returns title with HTML entities
+            Mock(choices=[Mock(message=Mock(content="MP calls for &#8216;urgent&#8217; action on flooding"))]),
+            # Second call: author extraction
+            Mock(choices=[Mock(message=Mock(content="Jane Smith"))]),
+        ]
+        html = """
+        <html>
+            <body>
+                <div class="organicOCRSection">
+                    <div class="textArea">
+                        MP calls for urgent action on flooding. The member of parliament spoke at length about
+                        the ongoing infrastructure challenges facing the constituency and surrounding areas.
+                    </div>
+                </div>
+            </body>
+        </html>
+        """
+        extractor = GleanerArchiveExtractor()
+        url = "https://gleaner.newspaperarchive.com/kingston-gleaner/2021-11-07/page-5/"
+
+        # When: extracting content
+        content = extractor.extract(html, url)
+
+        # Then: HTML entities in the LLM-returned title are decoded to Unicode
+        assert content.title == "MP calls for \u2018urgent\u2019 action on flooding"

--- a/tests/article_extractor/extractors/test_gleaner_extractor_v1.py
+++ b/tests/article_extractor/extractors/test_gleaner_extractor_v1.py
@@ -319,3 +319,29 @@ class TestGleanerExtractorV1OptionalFields:
 
         # Then: published_date is None (parsing failed gracefully)
         assert content.published_date is None
+
+
+class TestGleanerExtractorV1HtmlEntityDecoding:
+    """HTML entity decoding in extracted titles."""
+
+    async def test_title_with_html_entities_decoded(self):
+        # Given: HTML h1 title containing HTML entities
+        html = """
+        <html>
+            <body>
+                <h1 class="title">Gov&#8217;t calls for &#8216;urgent&#8217; infrastructure review</h1>
+                <div class="article-content">
+                    <p>Article content that is long enough to pass validation checks here.</p>
+                    <p>Second paragraph to ensure minimum content length requirements are met.</p>
+                </div>
+            </body>
+        </html>
+        """
+        extractor = GleanerExtractorV1()
+        url = "https://jamaica-gleaner.com/article/news/test"
+
+        # When: extracting content
+        content = extractor.extract(html, url)
+
+        # Then: HTML entities in the title are decoded to Unicode
+        assert content.title == "Gov\u2019t calls for \u2018urgent\u2019 infrastructure review"

--- a/tests/article_extractor/extractors/test_gleaner_extractor_v2.py
+++ b/tests/article_extractor/extractors/test_gleaner_extractor_v2.py
@@ -591,3 +591,36 @@ class TestGleanerExtractorV2JsonLdParsing:
         assert json_ld is not None
         assert json_ld["@type"] == "Article"
         assert json_ld["headline"] == "The Article"
+
+
+class TestGleanerExtractorV2HtmlEntityDecoding:
+    """HTML entity decoding in extracted titles."""
+
+    async def test_title_with_html_entities_decoded_via_json_ld(self):
+        # Given: JSON-LD headline containing HTML entities (json.loads does not decode these)
+        html = """
+        <html>
+            <head>
+                <script type="application/ld+json">
+                {
+                    "@type": "Article",
+                    "headline": "Gleaner&#8217;s report on &#8216;housing crisis&#8217;"
+                }
+                </script>
+            </head>
+            <body>
+                <div class="article--body">
+                    <p>Article content that is long enough to pass validation checks here.</p>
+                    <p>Second paragraph to ensure minimum content length requirements are met.</p>
+                </div>
+            </body>
+        </html>
+        """
+        extractor = GleanerExtractorV2()
+        url = "https://jamaica-gleaner.com/article/news/test"
+
+        # When: extracting content
+        content = extractor.extract(html, url)
+
+        # Then: HTML entities in the JSON-LD headline are decoded to Unicode
+        assert content.title == "Gleaner\u2019s report on \u2018housing crisis\u2019"

--- a/tests/article_extractor/extractors/test_jamaica_observer_extractor.py
+++ b/tests/article_extractor/extractors/test_jamaica_observer_extractor.py
@@ -281,3 +281,36 @@ class TestJamaicaObserverExtractorAuthorCleaning:
         # Then: "by " prefix is not treated as the BY-prefix format (only uppercase "BY " is stripped)
         # The pipe split still cleans up the title
         assert "Jane Doe" in result
+
+
+class TestJamaicaObserverExtractorHtmlEntityDecoding:
+    """HTML entity decoding in extracted titles."""
+
+    async def test_title_with_html_entities_decoded_via_json_ld(self):
+        # Given: JSON-LD headline containing HTML entities (json.loads does not decode these)
+        html = """
+        <html>
+            <head>
+                <script type="application/ld+json">
+                {
+                    "@type": "NewsArticle",
+                    "headline": "MP calls for NWA to address &#8216;ongoing flooding&#8217;"
+                }
+                </script>
+            </head>
+            <body>
+                <div class="body content-single-wrap">
+                    <p>Article content that is long enough to pass validation checks here.</p>
+                    <p>Second paragraph to ensure minimum content length requirements are met.</p>
+                </div>
+            </body>
+        </html>
+        """
+        extractor = JamaicaObserverExtractor()
+        url = "https://www.jamaicaobserver.com/2026/04/09/test/"
+
+        # When: extracting content
+        content = extractor.extract(html, url)
+
+        # Then: HTML entities in the JSON-LD headline are decoded to Unicode
+        assert content.title == "MP calls for NWA to address \u2018ongoing flooding\u2019"

--- a/tests/article_extractor/test_models.py
+++ b/tests/article_extractor/test_models.py
@@ -1,0 +1,69 @@
+"""Tests for ExtractedArticleContent model validation and normalization."""
+import pytest
+
+from src.article_extractor.models import ExtractedArticleContent
+
+FULL_TEXT_MIN = "x" * 50
+
+
+class TestExtractedArticleContentTitleNormalization:
+    """Tests for HTML entity decoding in article titles."""
+
+    async def test_title_curly_quotes_decoded(self):
+        # Given: title with HTML curly quote entities (the exact bug report example)
+        raw_title = "St Thomas Eastern MP calls for NWA to address &#8216;ongoing flooding&#8217; in Port Morant"
+
+        # When: creating ExtractedArticleContent
+        content = ExtractedArticleContent(title=raw_title, full_text=FULL_TEXT_MIN)
+
+        # Then: entities are decoded to Unicode curly quotes
+        assert content.title == "St Thomas Eastern MP calls for NWA to address \u2018ongoing flooding\u2019 in Port Morant"
+
+    async def test_title_amp_entity_decoded(self):
+        # Given: title with &amp; entity
+        # When / Then
+        content = ExtractedArticleContent(title="Roads &amp; Infrastructure Ministry", full_text=FULL_TEXT_MIN)
+        assert content.title == "Roads & Infrastructure Ministry"
+
+    async def test_title_quot_entity_decoded(self):
+        # Given: title with &quot; entity
+        content = ExtractedArticleContent(title='PM says &quot;no tolerance&quot; for corruption', full_text=FULL_TEXT_MIN)
+        assert content.title == 'PM says "no tolerance" for corruption'
+
+    async def test_title_ellipsis_entity_decoded(self):
+        # Given: title with &#8230; (ellipsis) entity
+        content = ExtractedArticleContent(title="MPs debate budget&#8230; again", full_text=FULL_TEXT_MIN)
+        assert content.title == "MPs debate budget\u2026 again"
+
+    async def test_title_angle_brackets_decoded(self):
+        # Given: title with &lt; / &gt; entities
+        content = ExtractedArticleContent(title="Scores &lt; 50 flagged for review", full_text=FULL_TEXT_MIN)
+        assert content.title == "Scores < 50 flagged for review"
+
+    async def test_title_with_no_entities_passes_through_unchanged(self):
+        # Given: a plain title with no HTML entities
+        plain = "St Thomas Eastern MP calls for action"
+        content = ExtractedArticleContent(title=plain, full_text=FULL_TEXT_MIN)
+        assert content.title == plain
+
+    async def test_title_already_decoded_unicode_unchanged(self):
+        # Given: title that already contains the decoded Unicode characters (idempotency)
+        decoded = "MP calls for \u2018accountability\u2019 in spending"
+        content = ExtractedArticleContent(title=decoded, full_text=FULL_TEXT_MIN)
+        assert content.title == decoded
+
+    async def test_title_mixed_entities_and_plain_text(self):
+        # Given: title mixing HTML entities and regular text
+        content = ExtractedArticleContent(
+            title="Gov&#8217;t &amp; Opposition clash over &#8216;secret&#8217; report",
+            full_text=FULL_TEXT_MIN,
+        )
+        assert content.title == "Gov\u2019t & Opposition clash over \u2018secret\u2019 report"
+
+    async def test_title_stripping_still_applied_after_decode(self):
+        # Given: title with leading/trailing whitespace around entities
+        content = ExtractedArticleContent(
+            title="  &#8216;Breaking News&#8217;  ",
+            full_text=FULL_TEXT_MIN,
+        )
+        assert content.title == "\u2018Breaking News\u2019"


### PR DESCRIPTION
Problem

Article titles containing HTML entities (e.g. &#8216;, &#8217;) are stored verbatim instead of being decoded to their Unicode equivalents (', ').

Root Cause

No call to html.unescape() (from Python's standard library) exists anywhere in the title extraction pipeline. Titles flow from RSS feeds and HTML scrapers into the database without entity decoding.

Affected code paths — every discoverer and extractor that handles titles:

Issues:
fixes #216