### PR TITLE
fix: extract works on premium gleaner articles

### DIFF
--- a/src/article_extractor/extractors/gleaner_extractor_v2.py
+++ b/src/article_extractor/extractors/gleaner_extractor_v2.py
@@ -1,4 +1,5 @@
 """Article extractor for Jamaica Gleaner news source (V2 - JSON-LD + CSS hybrid)."""
+import base64
 import json
 from datetime import datetime, timezone
 from bs4 import BeautifulSoup
@@ -138,11 +139,77 @@ class GleanerExtractorV2:
         # If no title found from any source, raise error (fail-fast)
         raise ValueError(f"Could not extract title from article: {url}")
 
+    def _is_premium_article(self, soup: BeautifulSoup) -> bool:
+        """
+        Check if the article is a premium (paywalled) article.
+
+        Premium articles have their content base64-encoded in Drupal settings JSON
+        rather than rendered in the DOM, because the Piano.js paywall injects it
+        client-side.
+
+        Args:
+            soup: BeautifulSoup parsed HTML
+
+        Returns:
+            True if the article is marked as premium, False otherwise
+        """
+        drupal_settings = self._extract_drupal_settings(soup)
+        if drupal_settings is None:
+            return False
+        piano_fields = drupal_settings.get("gleanerPianoFields", {})
+        return piano_fields.get("premium") == "1"
+
+    def _extract_drupal_settings(self, soup: BeautifulSoup) -> dict | None:
+        """
+        Extract and parse the Drupal settings JSON from the page.
+
+        Args:
+            soup: BeautifulSoup parsed HTML
+
+        Returns:
+            Parsed Drupal settings dict, or None if not found or malformed
+        """
+        script_tag = soup.find("script", attrs={"data-drupal-selector": "drupal-settings-json"})
+        if not script_tag or not script_tag.string:
+            return None
+        try:
+            return json.loads(script_tag.string)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    def _extract_premium_content(self, soup: BeautifulSoup) -> BeautifulSoup | None:
+        """
+        Extract article content from the base64-encoded premium content blob.
+
+        Premium articles store their rendered HTML body as base64-encoded JSON
+        inside the Drupal settings JSON under paywalled_jsonld.premiumContent.
+
+        Args:
+            soup: BeautifulSoup parsed HTML
+
+        Returns:
+            BeautifulSoup fragment of the article body, or None if extraction fails
+        """
+        drupal_settings = self._extract_drupal_settings(soup)
+        if drupal_settings is None:
+            return None
+
+        try:
+            b64_content = drupal_settings["paywalled_jsonld"]["premiumContent"]
+            decoded = json.loads(base64.b64decode(b64_content))
+            rendered_body = decoded["rendered_body"]
+            return BeautifulSoup(rendered_body, "lxml")
+        except (KeyError, json.JSONDecodeError, TypeError, Exception):
+            return None
+
     def _extract_full_text(self, soup: BeautifulSoup, url: str) -> str:
         """
         Extract article body paragraphs with priority fallback chain.
 
-        Priority:
+        For premium articles, content is extracted from the base64-encoded
+        premium content blob in Drupal settings JSON.
+
+        For non-premium articles:
         1. div.article--body (new site structure)
         2. div.article-content (legacy site structure)
         3. div.field-name-body (older legacy structure)
@@ -157,7 +224,14 @@ class GleanerExtractorV2:
         Raises:
             ValueError: If article body cannot be extracted or is too short
         """
-        # Try selectors in priority order
+        # Premium articles: content is base64-encoded in Drupal settings JSON
+        if self._is_premium_article(soup):
+            premium_soup = self._extract_premium_content(soup)
+            if premium_soup is None:
+                raise ValueError(f"Premium article but could not decode content: {url}")
+            return self._extract_paragraphs(premium_soup, url)
+
+        # Non-premium: try CSS selectors in priority order
         content_container = None
 
         # Priority 1: div.article--body (new site)
@@ -174,8 +248,23 @@ class GleanerExtractorV2:
         if not content_container:
             raise ValueError(f"Could not find article content container: {url}")
 
-        # Extract all paragraphs
-        paragraphs = content_container.find_all("p")
+        return self._extract_paragraphs(content_container, url)
+
+    def _extract_paragraphs(self, container: BeautifulSoup, url: str) -> str:
+        """
+        Extract and filter paragraphs from an HTML container.
+
+        Args:
+            container: BeautifulSoup element containing <p> tags
+            url: Article URL for error context
+
+        Returns:
+            Full article text as string
+
+        Raises:
+            ValueError: If no valid paragraphs or text too short
+        """
+        paragraphs = container.find_all("p")
 
         if not paragraphs:
             raise ValueError(f"No paragraphs found in article content: {url}")

--- a/tests/article_extractor/conftest.py
+++ b/tests/article_extractor/conftest.py
@@ -22,6 +22,12 @@ def gleaner_html_v1(fixtures_dir: Path) -> str:
 
 
 @pytest.fixture
+def gleaner_html_v2_premium(fixtures_dir: Path) -> str:
+    """Load Gleaner premium article HTML fixture (paywalled, no article--body)."""
+    return (fixtures_dir / "gleaner_article_v2_premium.html").read_text(encoding="utf-8")
+
+
+@pytest.fixture
 def gleaner_archive_html(fixtures_dir: Path) -> str:
     """Load Gleaner archive page HTML fixture (OCR-based historical newspaper)."""
     return (fixtures_dir / "gleaner_archive_2021-11-07-page-5.html").read_text(encoding="utf-8")

--- a/tests/article_extractor/extractors/test_gleaner_extractor_v2.py
+++ b/tests/article_extractor/extractors/test_gleaner_extractor_v2.py
@@ -1,4 +1,6 @@
 """Tests for GleanerExtractorV2 (JSON-LD + CSS hybrid strategy)."""
+import base64
+import json
 import pytest
 from datetime import timezone
 
@@ -624,3 +626,114 @@ class TestGleanerExtractorV2HtmlEntityDecoding:
 
         # Then: HTML entities in the JSON-LD headline are decoded to Unicode
         assert content.title == "Gleaner\u2019s report on \u2018housing crisis\u2019"
+
+
+class TestGleanerExtractorV2PremiumArticles:
+    """Tests for premium (paywalled) article extraction via base64-encoded content."""
+
+    async def test_extract_premium_article_full(self, gleaner_html_v2_premium: str):
+        # Given: premium Gleaner article with content in paywalled_jsonld
+        extractor = GleanerExtractorV2()
+        url = "https://jamaica-gleaner.com/article/news/20260426/nswma-hiring-row-sparks-two-year-tension-between-senior-officials"
+
+        # When: extracting content
+        content = extractor.extract(gleaner_html_v2_premium, url)
+
+        # Then: all fields are extracted correctly
+        assert isinstance(content, ExtractedArticleContent)
+        assert content.title == "NSWMA hiring row sparks two-year tension between senior officials"
+        assert content.full_text.startswith("An \u201cirregular\u201d recruitment exercise")
+        assert "National Solid Waste Management Authority" in content.full_text
+        assert content.author == "Kimone Francis - Senior Staff Reporter"
+        assert content.published_date is not None
+        assert content.published_date.year == 2026
+        assert content.published_date.month == 4
+        assert content.published_date.day == 26
+
+    async def test_premium_article_filters_email_paragraphs(self, gleaner_html_v2_premium: str):
+        # Given: premium article with email paragraph in rendered_body
+        extractor = GleanerExtractorV2()
+        url = "https://jamaica-gleaner.com/article/news/test"
+
+        # When: extracting content
+        content = extractor.extract(gleaner_html_v2_premium, url)
+
+        # Then: email paragraph is filtered out
+        assert "kimone.francis@gleanerjm.com" not in content.full_text
+
+    async def test_premium_article_with_malformed_base64_raises_value_error(self):
+        # Given: premium article with invalid base64 in premiumContent
+        html = """
+        <html>
+            <head>
+                <script type="application/ld+json">
+                {"@type": "Article", "headline": "Test Premium"}
+                </script>
+                <script type="application/json" data-drupal-selector="drupal-settings-json">
+                {"gleanerPianoFields":{"premium":"1"},"paywalled_jsonld":{"premiumContent":"!!!not-valid-base64!!!"}}
+                </script>
+            </head>
+            <body><h1 class="article--title">Test Premium</h1></body>
+        </html>
+        """
+        extractor = GleanerExtractorV2()
+        url = "https://jamaica-gleaner.com/article/news/test"
+
+        # When/Then: extraction raises ValueError
+        with pytest.raises(ValueError) as exc_info:
+            extractor.extract(html, url)
+
+        assert "Premium article but could not decode content" in str(exc_info.value)
+
+    async def test_premium_article_with_missing_rendered_body_raises_value_error(self):
+        # Given: premium article with base64 content missing rendered_body key
+        bad_content = base64.b64encode(json.dumps({"nid": "123"}).encode()).decode()
+        html = f"""
+        <html>
+            <head>
+                <script type="application/ld+json">
+                {{"@type": "Article", "headline": "Test Premium"}}
+                </script>
+                <script type="application/json" data-drupal-selector="drupal-settings-json">
+                {{"gleanerPianoFields":{{"premium":"1"}},"paywalled_jsonld":{{"premiumContent":"{bad_content}"}}}}
+                </script>
+            </head>
+            <body><h1 class="article--title">Test Premium</h1></body>
+        </html>
+        """
+        extractor = GleanerExtractorV2()
+        url = "https://jamaica-gleaner.com/article/news/test"
+
+        # When/Then: extraction raises ValueError
+        with pytest.raises(ValueError) as exc_info:
+            extractor.extract(html, url)
+
+        assert "Premium article but could not decode content" in str(exc_info.value)
+
+    async def test_non_premium_article_uses_css_selectors(self):
+        # Given: non-premium article with both CSS body and paywalled_jsonld present
+        html = """
+        <html>
+            <head>
+                <script type="application/ld+json">
+                {"@type": "Article", "headline": "Non Premium Article"}
+                </script>
+                <script type="application/json" data-drupal-selector="drupal-settings-json">
+                {"gleanerPianoFields":{"premium":"0"}}
+                </script>
+            </head>
+            <body>
+                <div class="article--body">
+                    <p>This content comes from the normal CSS selector path, not premium decoding.</p>
+                </div>
+            </body>
+        </html>
+        """
+        extractor = GleanerExtractorV2()
+        url = "https://jamaica-gleaner.com/article/news/test"
+
+        # When: extracting content
+        content = extractor.extract(html, url)
+
+        # Then: content extracted from CSS selectors, not premium path
+        assert content.full_text.startswith("This content comes from the normal CSS selector")

--- a/tests/article_extractor/fixtures/gleaner_article_v2_premium.html
+++ b/tests/article_extractor/fixtures/gleaner_article_v2_premium.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="og: https://ogp.me/ns#">
+  <head>
+    <meta charset="utf-8" />
+<meta name="description" content="An &ldquo;irregular&rdquo; recruitment exercise at the National Solid Waste Management Authority (NSWMA) has triggered a two-year impasse between the entity&rsquo;s executive director and its internal audit manager, creating a &ldquo;hostile&rdquo; working environment." />
+<link rel="canonical" href="http://jamaica-gleaner.com/article/news/20260426/nswma-hiring-row-sparks-two-year-tension-between-senior-officials" />
+<meta property="og:title" content="NSWMA hiring row sparks two-year tension between senior officials" />
+<script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "NSWMA hiring row sparks two-year tension between senior officials ",
+    "image": "http://jamaica-gleaner.com/sites/default/files/media/article_images/2026/04/26/3409552/8478427.jpg",
+    "datePublished": "2026-04-26T01:07:15-04:00",
+    "dateModified": "2026-04-26T01:07:15-04:00",
+    "author": {
+        "@type": "Person",
+        "name": "Kimone Francis - Senior Staff Reporter"
+    },
+    "isAccessibleForFree": false,
+    "hasPart": {
+        "@type": "WebPageElement",
+        "isAccessibleForFree": false,
+        "cssSelector": ".paywall"
+    }
+}</script>
+
+    <title>NSWMA hiring row sparks two-year tension between senior officials | Jamaica Gleaner</title>
+
+    <script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","currentPath":"node\/13332"},"gleanerConfig":{"piano_enabled":1,"piano_environment":"production"},"gleanerPianoFields":{"premium":"1","onlineSectionName":"News"},"paywalled_jsonld":{"premiumContent":"eyJuaWQiOiAiMTMzMzIiLCAicmVuZGVyZWRfYm9keSI6ICJcbiAgICAgICAgICAgIDxkaXY+IDxwPkFuIFx1MjAxY2lycmVndWxhclx1MjAxZCByZWNydWl0bWVudCBleGVyY2lzZSBhdCB0aGUgTmF0aW9uYWwgU29saWQgV2FzdGUgTWFuYWdlbWVudCBBdXRob3JpdHkgKE5TV01BKSBoYXMgdHJpZ2dlcmVkIGEgdHdvLXllYXIgaW1wYXNzZSBiZXR3ZWVuIHRoZSBlbnRpdHlcdTIwMTlzIGV4ZWN1dGl2ZSBkaXJlY3RvciBhbmQgaXRzIGludGVybmFsIGF1ZGl0IG1hbmFnZXIsIGNyZWF0aW5nIGEgXHUyMDFjaG9zdGlsZVx1MjAxZCB3b3JraW5nIGVudmlyb25tZW50LjwvcD4gPHA+VGhlIGNvbmNsdXNpb24gd2FzIHJlYWNoZWQgYnkgdGhlIE1pbmlzdHJ5IG9mIExvY2FsIEdvdmVybm1lbnQgYW5kIENvbW11bml0eSBEZXZlbG9wbWVudFx1MjAxOXMgY2hpZWYgaW50ZXJuYWwgYXVkaXRvciwgZm9sbG93aW5nIGEgY29tcGxhaW50IHRoYXQgdGhlIG91dGNvbWUgb2YgYSBzZWxlY3Rpb24gcHJvY2VzcyB0byBmaWxsIGFuIGFzc2lzdGFudCBhdWRpdG9yIHBvc2l0aW9uIHdhcyBhbHRlcmVkIGluIGZhdm91ciBvZiBhIGNhbmRpZGF0ZSB3aG8gd2FzIG91dHNjb3JlZCBieSBhbm90aGVyLjwvcD4gPHA+QWNjb3JkaW5nIHRvIGFuIGludGVybmFsIG1pbmlzdHJ5IG1lbW8gcmV2aWV3ZWQgYnkgPGI+IFRoZSBTdW5kYXkgR2xlYW5lcjwvYj4sIGludGVydmlld3MgY29uZHVjdGVkIGluIEphbnVhcnkgMjAyNCByZXN1bHRlZCBpbiBvbmUgY2FuZGlkYXRlIGZyb20gdGhlIGZpbmFuY2UgZGVwYXJ0bWVudCBzY29yaW5nIDczLjMzIHBlciBjZW50IGFuZCBhbm90aGVyIGZyb20gdGhlIHBhcmtzIGFuZCBnYXJkZW5zIGRlcGFydG1lbnQgZ2V0dGluZyA2Ny42NiBwZXIgY2VudC48L3A+IDxwPiA8aT5raW1vbmUuZnJhbmNpc0BnbGVhbmVyam0uY29tPC9pPiA8L3A+PC9kaXY+XG4gICAgICAifQ=="},"user":{"uid":0}}</script>
+</head>
+  <body>
+    <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+      <header>
+        <nav>Jamaica Gleaner Navigation</nav>
+      </header>
+      <main>
+        <article>
+          <h1 class="article--title">NSWMA hiring row sparks two-year tension between senior officials</h1>
+          <div class="article--authors">Kimone Francis/Senior Staff Reporter</div>
+          <!-- No article--body div for premium articles - content is in paywalled_jsonld -->
+        </article>
+      </main>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Premium (paywalled) Gleaner articles don't render div.article--body in
  server-side HTML. Instead, the full article HTML is base64-encoded in the
  Drupal settings JSON (paywalled_jsonld.premiumContent) and injected into
  the DOM client-side by Piano.js. Our scraper doesn't execute JS, so it
  never saw the content.

  The V2 extractor now checks gleanerPianoFields.premium in the Drupal
  settings JSON. For premium articles, it decodes the base64 blob, parses
  the rendered_body HTML, and extracts paragraphs from it. Non-premium
  articles continue using the existing CSS selector chain unchanged.

Issues:
fixes #239