### PR TITLE
fix(server): order related articles by entity count, confidence, then…

### DIFF
--- a/src/article_persistence/queries/articles.sql
+++ b/src/article_persistence/queries/articles.sql
@@ -71,6 +71,7 @@ WITH source_article AS (
 ),
 article_classifications AS (
     SELECT article_id,
+           MAX(confidence_score) AS max_confidence,
            jsonb_agg(jsonb_build_object(
                'classifier_type', classifier_type,
                'confidence_score', confidence_score,
@@ -86,8 +87,6 @@ related_scores AS (
     INNER JOIN source_article sa ON src_ae.article_id = sa.id
     WHERE ae.article_id != sa.id
     GROUP BY ae.article_id
-    ORDER BY shared_entity_count DESC
-    LIMIT :limit
 )
 SELECT
     a.public_id, a.url, a.title, a.section, a.published_date,
@@ -103,5 +102,6 @@ LEFT JOIN article_classifications ac ON a.id = ac.article_id
 LEFT JOIN article_entities ae ON a.id = ae.article_id
 LEFT JOIN entities e ON ae.entity_id = e.id
 GROUP BY a.id, a.public_id, a.url, a.title, a.section, a.published_date,
-         a.full_text, ns.id, ac.classifications, rs.shared_entity_count
-ORDER BY rs.shared_entity_count DESC, a.published_date DESC;
+         a.full_text, ns.id, ac.classifications, ac.max_confidence, rs.shared_entity_count
+ORDER BY rs.shared_entity_count DESC, COALESCE(ac.max_confidence, 0) DESC, a.published_date DESC
+LIMIT :limit;

--- a/tests/article_persistence/repositories/test_article_repository.py
+++ b/tests/article_persistence/repositories/test_article_repository.py
@@ -10,8 +10,10 @@ from src.article_persistence.models.domain import Article
 from tests.article_persistence.utils import (
     create_test_article,
     create_test_article_entity,
+    create_test_classification,
     create_test_entity,
     create_test_news_source,
+    insert_article_with_date,
 )
 
 
@@ -568,6 +570,74 @@ class TestGetRelatedArticlesHappyPath:
 
         # Then: at most 5 results returned
         assert len(results) == 5
+
+
+class TestGetRelatedArticlesOrdering:
+    """Tests that verify the confidence → date → entity count sort order."""
+
+    async def test_entity_count_sorts_before_confidence(
+        self,
+        db_connection: asyncpg.Connection,
+    ):
+        # Given:
+        #   article_a: 2 shared entities, low confidence (0.5)
+        #   article_b: 1 shared entity,  high confidence (0.9), newer date
+        #   article_c: 1 shared entity,  low confidence (0.5), older date
+        older = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        newer = datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+        source = await insert_article_with_date(db_connection, url="https://example.com/ord-src", published_date=older)
+        article_a = await insert_article_with_date(db_connection, url="https://example.com/ord-a", published_date=older)
+        article_b = await insert_article_with_date(db_connection, url="https://example.com/ord-b", published_date=newer)
+        article_c = await insert_article_with_date(db_connection, url="https://example.com/ord-c", published_date=older)
+
+        entity1 = await create_test_entity(db_connection, name="Petrojam Ord", normalized_name="petrojam-ord")
+        entity2 = await create_test_entity(db_connection, name="NWC Ord", normalized_name="nwc-ord")
+
+        # source and article_a share both entities; article_b and article_c share only entity1
+        for art in [source, article_a]:
+            await create_test_article_entity(db_connection, art.id, entity1.id)
+            await create_test_article_entity(db_connection, art.id, entity2.id)
+        for art in [article_b, article_c]:
+            await create_test_article_entity(db_connection, art.id, entity1.id)
+
+        await create_test_classification(db_connection, article_a.id, confidence_score=0.5)
+        await create_test_classification(db_connection, article_b.id, confidence_score=0.9)
+        await create_test_classification(db_connection, article_c.id, confidence_score=0.5)
+
+        repo = ArticleRepository()
+
+        # When: related articles are fetched
+        results = await repo.get_related_articles_by_public_id(db_connection, source.public_id, limit=10)
+
+        # Then: order is A (2 entities) → B (1 entity, high conf) → C (1 entity, low conf, older)
+        result_ids = [r.public_id for r in results]
+        assert result_ids.index(article_a.public_id) < result_ids.index(article_b.public_id)
+        assert result_ids.index(article_b.public_id) < result_ids.index(article_c.public_id)
+
+    async def test_unclassified_articles_sort_last(
+        self,
+        db_connection: asyncpg.Connection,
+    ):
+        # Given: two related articles — one classified (confidence 0.7), one unclassified
+        source = await create_test_article(db_connection, url="https://example.com/ord-unclass-src", news_source_id=1)
+        classified = await create_test_article(db_connection, url="https://example.com/ord-unclass-yes", news_source_id=1)
+        unclassified = await create_test_article(db_connection, url="https://example.com/ord-unclass-no", news_source_id=1)
+
+        entity = await create_test_entity(db_connection, name="NSWMA Ord", normalized_name="nswma-ord")
+        for art in [source, classified, unclassified]:
+            await create_test_article_entity(db_connection, art.id, entity.id)
+
+        await create_test_classification(db_connection, classified.id, confidence_score=0.7)
+
+        repo = ArticleRepository()
+
+        # When: related articles are fetched
+        results = await repo.get_related_articles_by_public_id(db_connection, source.public_id, limit=10)
+
+        # Then: classified article appears before the unclassified one
+        result_ids = [r.public_id for r in results]
+        assert result_ids.index(classified.public_id) < result_ids.index(unclassified.public_id)
 
 
 class TestGetRelatedArticlesEdgeCases:

--- a/tests/article_persistence/utils.py
+++ b/tests/article_persistence/utils.py
@@ -3,9 +3,10 @@
 import asyncpg
 from datetime import datetime, timezone
 
-from src.article_persistence.models.domain import Article, ArticleEntity, Entity, NewsSource
+from src.article_persistence.models.domain import Article, ArticleEntity, Classification, Entity, NewsSource
 from src.article_persistence.repositories.article_repository import ArticleRepository
 from src.article_persistence.repositories.article_entity_repository import ArticleEntityRepository
+from src.article_persistence.repositories.classification_repository import ClassificationRepository
 from src.article_persistence.repositories.entity_repository import EntityRepository
 from src.article_persistence.repositories.news_source_repository import NewsSourceRepository
 
@@ -116,6 +117,24 @@ async def create_test_article_entity(
         classifier_type=classifier_type,
     )
     return await repository.link_article_to_entity(conn, article_entity)
+
+
+async def create_test_classification(
+    conn: asyncpg.Connection,
+    article_id: int,
+    confidence_score: float = 0.8,
+    classifier_type: str = "CORRUPTION",
+    model_name: str = "gpt-4o-mini",
+) -> Classification:
+    """Insert a classification for an article with the given confidence score."""
+    repo = ClassificationRepository()
+    classification = Classification(
+        article_id=article_id,
+        classifier_type=classifier_type,
+        confidence_score=confidence_score,
+        model_name=model_name,
+    )
+    return await repo.insert_classification(conn, classification)
 
 
 async def insert_article_with_date(


### PR DESCRIPTION
… date

Moves LIMIT from the related_scores CTE to the outer SELECT so all candidates are ranked before truncation. Adds max_confidence to the article_classifications CTE and updates ORDER BY to shared_entity_count DESC, confidence DESC, published_date DESC. Unclassified articles coalesce to 0 and sort last.

Adds TestGetRelatedArticlesOrdering with two repo-layer tests covering the full sort key precedence and the unclassified-sorts-last behaviour. Adds create_test_classification helper to tests/article_persistence/utils.py.