### PR TITLE
feat(analytics): track article detail page views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ analytics.capture_with_common_props(
 
 **`is_internal_request(request)`** — returns `True` if `X-Internal-Request: true` header is present. Update this method to change the internal traffic detection strategy.
 
+**`get_navigation_source(request)`** — reads the `X-Source` header and normalizes it against `KNOWN_NAVIGATION_SOURCES` (`"home" | "search" | "related" | "direct"`). Unknown or missing values become `"unknown"`. The frontend sets `X-Source` based on where the user clicked the link (or, for SSR, where the route arrived from). To add a new navigation source, extend the `KNOWN_NAVIGATION_SOURCES` frozenset in `src/analytics/client.py`.
+
 **Disabled mode** — set `POSTHOG_API_KEY=` (empty) to silently disable all event tracking. All `capture_*` calls become no-ops. Useful for local dev without a PostHog project.
 
 **Environment variables:** `POSTHOG_API_KEY`, `POSTHOG_HOST`, `APP_ENV`

--- a/src/analytics/client.py
+++ b/src/analytics/client.py
@@ -9,6 +9,11 @@ from fastapi import Request
 from loguru import logger
 
 
+KNOWN_NAVIGATION_SOURCES: frozenset[str] = frozenset(
+    {"home", "search", "related", "direct"}
+)
+
+
 class AnalyticsClient:
     """Wraps the PostHog Python SDK with graceful no-op behavior when unconfigured.
 
@@ -72,6 +77,17 @@ class AnalyticsClient:
         Update this method to change the internal traffic detection strategy.
         """
         return request.headers.get("X-Internal-Request", "").lower() == "true"
+
+    def get_navigation_source(self, request: Request) -> str:
+        """Return the normalized navigation source for an incoming request.
+
+        Reads the X-Source header (set by the frontend when linking to a page)
+        and normalizes it against KNOWN_NAVIGATION_SOURCES. Unknown or missing
+        values become "unknown" so the property is always present and stable
+        for PostHog filtering.
+        """
+        raw = (request.headers.get("X-Source") or "").strip().lower()
+        return raw if raw in KNOWN_NAVIGATION_SOURCES else "unknown"
 
     def capture_with_common_props(
         self,

--- a/src/server/articles/router.py
+++ b/src/server/articles/router.py
@@ -58,14 +58,38 @@ async def get_related_articles(
 
 @router.get("/{public_id}", response_model=ArticleSearchResultSchema)
 async def get_article(
+    request: Request,
     public_id: UUID,
     conn: Annotated[asyncpg.Connection, Depends(get_db)],
     service: Annotated[ArticleSearchService, Depends(_get_service)],
+    analytics: Annotated[AnalyticsClient, Depends(get_analytics)],
 ) -> ArticleSearchResultSchema:
     result = await service.get_by_public_id(conn, public_id)
     if result is None:
         raise HTTPException(status_code=404, detail="Article not found")
+
+    _capture_detail_view_event(analytics, request, public_id, result)
+
     return ArticleSearchResultSchema.model_validate(result)
+
+
+def _capture_detail_view_event(
+    analytics: AnalyticsClient,
+    request: Request,
+    public_id: UUID,
+    result,
+) -> None:
+    analytics.capture_with_common_props(
+        distinct_id=analytics.get_distinct_id(request),
+        event="article:detail_view",
+        properties={
+            "article_public_id": str(public_id),
+            "article_title": result.title,
+            "article_section": result.section,
+            "navigation_source": analytics.get_navigation_source(request),
+        },
+        is_internal=analytics.is_internal_request(request),
+    )
 
 
 def _capture_search_event(

--- a/tests/analytics/test_analytics_client.py
+++ b/tests/analytics/test_analytics_client.py
@@ -197,3 +197,35 @@ class TestAnalyticsClientRequestHelpers:
 
         # When / Then
         assert client.is_internal_request(request) is False
+
+    async def test_get_navigation_source_returns_known_value(self):
+        # Given: a request with X-Source set to a known navigation source
+        client = AnalyticsClient(api_key="")
+        request = self._make_request({"X-Source": "home"})
+
+        # When / Then
+        assert client.get_navigation_source(request) == "home"
+
+    async def test_get_navigation_source_normalizes_case_and_whitespace(self):
+        # Given: a request with mixed-case + whitespace around a known value
+        client = AnalyticsClient(api_key="")
+        request = self._make_request({"X-Source": "  SEARCH  "})
+
+        # When / Then: normalized to lowercase trimmed value
+        assert client.get_navigation_source(request) == "search"
+
+    async def test_get_navigation_source_unknown_value_becomes_unknown(self):
+        # Given: a request with X-Source set to a value not in the allowlist
+        client = AnalyticsClient(api_key="")
+        request = self._make_request({"X-Source": "weird-source"})
+
+        # When / Then: defensively normalized to "unknown"
+        assert client.get_navigation_source(request) == "unknown"
+
+    async def test_get_navigation_source_absent_header_becomes_unknown(self):
+        # Given: a request with no X-Source header
+        client = AnalyticsClient(api_key="")
+        request = self._make_request({})
+
+        # When / Then
+        assert client.get_navigation_source(request) == "unknown"

--- a/tests/server/articles/test_router.py
+++ b/tests/server/articles/test_router.py
@@ -11,6 +11,7 @@ Strategy:
 - Assert on mock_analytics.capture_with_common_props call arguments
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import asyncpg
@@ -288,4 +289,121 @@ class TestSearchAnalyticsInternalFlag:
         # Then: is_internal=False is passed to capture_with_common_props
         call_kwargs = mock_analytics.capture_with_common_props.call_args.kwargs
         assert call_kwargs["is_internal"] is False
+
+
+# ---------------------------------------------------------------------------
+# TestArticleDetailAnalytics
+# ---------------------------------------------------------------------------
+
+
+def _make_detail_result(
+    public_id: str = "11111111-1111-1111-1111-111111111111",
+    title: str = "Public Funds Misused",
+    section: str = "lead-stories",
+) -> SimpleNamespace:
+    """Build a minimal ArticleSearchResult-like object for ArticleSearchResultSchema.model_validate."""
+    return SimpleNamespace(
+        public_id=public_id,
+        url="https://example.com/article",
+        title=title,
+        section=section,
+        published_date=None,
+        news_source_id=1,
+        snippet=None,
+        entities=[],
+        classifications=[],
+        full_text=None,
+    )
+
+
+class TestArticleDetailAnalytics:
+    """article:detail_view is captured on successful GET /articles/{public_id}."""
+
+    _PUBLIC_ID = "11111111-1111-1111-1111-111111111111"
+
+    async def test_event_fired_with_x_source_header(
+        self, client: TestClient, mock_analytics: MagicMock
+    ):
+        # Given: service returns an article and the request includes X-Source
+        mock_analytics.get_navigation_source.return_value = "home"
+
+        with patch.object(
+            ArticleSearchService, "get_by_public_id", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = _make_detail_result(
+                public_id=self._PUBLIC_ID,
+                title="Public Funds Misused",
+                section="lead-stories",
+            )
+
+            # When: client fetches the article with X-Source: home
+            response = client.get(
+                f"/api/v1/articles/{self._PUBLIC_ID}",
+                headers={"X-Source": "home"},
+            )
+
+        # Then: HTTP succeeds and the detail-view event is captured
+        assert response.status_code == 200
+        mock_analytics.capture_with_common_props.assert_called_once()
+        call_kwargs = mock_analytics.capture_with_common_props.call_args.kwargs
+        assert call_kwargs["event"] == "article:detail_view"
+        assert call_kwargs["properties"]["article_public_id"] == self._PUBLIC_ID
+        assert call_kwargs["properties"]["article_title"] == "Public Funds Misused"
+        assert call_kwargs["properties"]["article_section"] == "lead-stories"
+        assert call_kwargs["properties"]["navigation_source"] == "home"
+
+    async def test_navigation_source_sourced_from_analytics_helper(
+        self, client: TestClient, mock_analytics: MagicMock
+    ):
+        # Given: get_navigation_source returns a controlled value
+        mock_analytics.get_navigation_source.return_value = "unknown"
+
+        with patch.object(
+            ArticleSearchService, "get_by_public_id", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = _make_detail_result(public_id=self._PUBLIC_ID)
+
+            # When: client fetches without X-Source
+            client.get(f"/api/v1/articles/{self._PUBLIC_ID}")
+
+        # Then: the helper's return value is passed through as navigation_source
+        call_kwargs = mock_analytics.capture_with_common_props.call_args.kwargs
+        assert call_kwargs["properties"]["navigation_source"] == "unknown"
+
+    async def test_event_not_fired_on_404(
+        self, client: TestClient, mock_analytics: MagicMock
+    ):
+        # Given: service returns None (article not found)
+        with patch.object(
+            ArticleSearchService, "get_by_public_id", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = None
+
+            # When: client fetches a non-existent article
+            response = client.get(f"/api/v1/articles/{self._PUBLIC_ID}")
+
+        # Then: HTTP 404 AND no analytics event is captured
+        assert response.status_code == 404
+        mock_analytics.capture_with_common_props.assert_not_called()
+
+    async def test_distinct_id_and_is_internal_propagated(
+        self, client: TestClient, mock_analytics: MagicMock
+    ):
+        # Given: analytics helpers return controlled values
+        mock_analytics.get_distinct_id.return_value = "frontend-posthog-id"
+        mock_analytics.is_internal_request.return_value = True
+        mock_analytics.get_navigation_source.return_value = "home"
+
+        with patch.object(
+            ArticleSearchService, "get_by_public_id", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = _make_detail_result(public_id=self._PUBLIC_ID)
+
+            # When: a detail request is made
+            client.get(f"/api/v1/articles/{self._PUBLIC_ID}")
+
+        # Then: distinct_id and is_internal are propagated to the event
+        call_kwargs = mock_analytics.capture_with_common_props.call_args.kwargs
+        assert call_kwargs["distinct_id"] == "frontend-posthog-id"
+        assert call_kwargs["is_internal"] is True
 


### PR DESCRIPTION
Capture article:detail_view PostHog event on GET /articles/{public_id} with article metadata and a navigation_source property sourced from the X-Source header (home | search | related | direct), so we can measure where detail-page traffic comes from.

Issues:
closes #255