### PR TITLE
feat(analytics): forward X-PostHog-Session-Id as $session_id on events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,13 @@ analytics.capture_with_common_props(
     event="category:object_action",
     properties={"property_name": value},
     is_internal=analytics.is_internal_request(request),
+    session_id=analytics.get_session_id(request),
 )
 ```
 
 **`get_distinct_id(request)`** — prefers `X-PostHog-Distinct-Id` header (frontend passes its PostHog ID to link events to the same person); falls back to a per-request UUID. Never uses client IP (shared NAT/VPN would merge unrelated users). Update this method when user auth is added.
+
+**`get_session_id(request)`** — reads the `X-PostHog-Session-Id` header (forwarded by the frontend's `apiFetch` wrapper) and returns it, or `None` when absent (SSR / pre-session clients). Pass the result as `session_id=` to `capture_with_common_props` — the client injects it as PostHog's reserved `$session_id` property only when non-None, so session-scoped queries can link the server-side event to the client session.
 
 **`is_internal_request(request)`** — returns `True` if `X-Internal-Request: true` header is present. Update this method to change the internal traffic detection strategy.
 

--- a/src/analytics/client.py
+++ b/src/analytics/client.py
@@ -67,6 +67,15 @@ class AnalyticsClient:
         """
         return request.headers.get("X-PostHog-Distinct-Id") or str(uuid4())
 
+    def get_session_id(self, request: Request) -> str | None:
+        """Extract the PostHog session_id from the X-PostHog-Session-Id header.
+
+        Returns None when the header is absent (e.g. SSR requests or clients
+        without an active PostHog session). Callers should omit `$session_id`
+        from event properties in that case rather than sending a placeholder.
+        """
+        return request.headers.get("X-PostHog-Session-Id") or None
+
     def is_internal_request(self, request: Request) -> bool:
         """Return True if the request originated from internal infrastructure.
 
@@ -96,12 +105,14 @@ class AnalyticsClient:
         properties: dict[str, Any] | None = None,
         *,
         is_internal: bool = False,
+        session_id: str | None = None,
     ) -> None:
         """Fire an analytics event with common properties automatically merged.
 
         Common properties injected into every event:
           - environment  (from APP_ENV env var, defaults to "development")
           - is_internal  (caller-provided, typically from is_internal_request())
+          - $session_id  (caller-provided when present; omitted when None)
 
         Use this method for all event tracking to ensure consistent properties.
         """
@@ -109,6 +120,12 @@ class AnalyticsClient:
             "environment": self.environment,
             "is_internal": is_internal,
         }
+        if session_id:
+            # $session_id is PostHog's reserved property name that links this
+            # server-side event to a client-side session. The leading $ is
+            # required — do not rename. See:
+            # https://posthog.com/docs/data/sessions#passing-session-ids-from-client-side-code-into-server-side-events
+            common["$session_id"] = session_id
         merged = {**common, **(properties or {})}
         self._capture(distinct_id=distinct_id, event=event, properties=merged)
 

--- a/src/server/articles/router.py
+++ b/src/server/articles/router.py
@@ -89,6 +89,7 @@ def _capture_detail_view_event(
             "navigation_source": analytics.get_navigation_source(request),
         },
         is_internal=analytics.is_internal_request(request),
+        session_id=analytics.get_session_id(request),
     )
 
 
@@ -100,6 +101,7 @@ def _capture_search_event(
 ) -> None:
     distinct_id = analytics.get_distinct_id(request)
     is_internal = analytics.is_internal_request(request)
+    session_id = analytics.get_session_id(request)
     # page == 1 means a fresh search or browse; page > 1 means the user clicked
     # Load More — the frontend reuses the same endpoint for both actions.
     if params.page == 1:
@@ -108,6 +110,7 @@ def _capture_search_event(
             event="search:query_submit",
             properties={"search_query": params.q, "results_count": total},
             is_internal=is_internal,
+            session_id=session_id,
         )
     else:
         analytics.capture_with_common_props(
@@ -119,4 +122,5 @@ def _capture_search_event(
                 "current_results_count": (params.page - 1) * params.page_size,
             },
             is_internal=is_internal,
+            session_id=session_id,
         )

--- a/tests/analytics/test_analytics_client.py
+++ b/tests/analytics/test_analytics_client.py
@@ -91,6 +91,46 @@ class TestAnalyticsClientEnabled:
         assert props["search_query"] == "budget"
         assert props["results_count"] == 5
 
+    async def test_capture_with_common_props_includes_session_id_when_provided(self):
+        # Given: an enabled client
+        with patch("src.analytics.client.posthog.Posthog") as MockPosthog:
+            mock_ph = MagicMock()
+            MockPosthog.return_value = mock_ph
+            client = AnalyticsClient(api_key="phc_test_key_123")
+
+            # When: capture_with_common_props is called with a session_id
+            client.capture_with_common_props(
+                distinct_id="user-xyz",
+                event="search:query_submit",
+                properties={"search_query": "budget"},
+                is_internal=False,
+                session_id="session-abc-123",
+            )
+
+        # Then: $session_id (PostHog's reserved key) is present on the event
+        props = mock_ph.capture.call_args.kwargs["properties"]
+        assert props["$session_id"] == "session-abc-123"
+
+    async def test_capture_with_common_props_omits_session_id_when_none(self):
+        # Given: an enabled client
+        with patch("src.analytics.client.posthog.Posthog") as MockPosthog:
+            mock_ph = MagicMock()
+            MockPosthog.return_value = mock_ph
+            client = AnalyticsClient(api_key="phc_test_key_123")
+
+            # When: capture_with_common_props is called without a session_id
+            client.capture_with_common_props(
+                distinct_id="user-xyz",
+                event="search:query_submit",
+                properties={"search_query": "budget"},
+                is_internal=False,
+                session_id=None,
+            )
+
+        # Then: $session_id is absent (not present as null or empty)
+        props = mock_ph.capture.call_args.kwargs["properties"]
+        assert "$session_id" not in props
+
     async def test_capture_exception_is_swallowed(self):
         # Given: a client whose SDK raises on capture
         with patch("src.analytics.client.posthog.Posthog") as MockPosthog:
@@ -197,6 +237,30 @@ class TestAnalyticsClientRequestHelpers:
 
         # When / Then
         assert client.is_internal_request(request) is False
+
+    async def test_get_session_id_returns_header_when_present(self):
+        # Given: a request with the PostHog session_id header
+        client = AnalyticsClient(api_key="")
+        request = self._make_request({"X-PostHog-Session-Id": "session-xyz-789"})
+
+        # When / Then
+        assert client.get_session_id(request) == "session-xyz-789"
+
+    async def test_get_session_id_returns_none_when_header_absent(self):
+        # Given: a request without the PostHog session_id header
+        client = AnalyticsClient(api_key="")
+        request = self._make_request({})
+
+        # When / Then: None (so callers can omit $session_id entirely)
+        assert client.get_session_id(request) is None
+
+    async def test_get_session_id_returns_none_when_header_empty(self):
+        # Given: a request with an empty session_id header value
+        client = AnalyticsClient(api_key="")
+        request = self._make_request({"X-PostHog-Session-Id": ""})
+
+        # When / Then
+        assert client.get_session_id(request) is None
 
     async def test_get_navigation_source_returns_known_value(self):
         # Given: a request with X-Source set to a known navigation source

--- a/tests/server/articles/test_router.py
+++ b/tests/server/articles/test_router.py
@@ -38,6 +38,7 @@ def mock_analytics() -> MagicMock:
     mock.environment = "test"
     mock.get_distinct_id.return_value = "test-distinct-id"
     mock.is_internal_request.return_value = False
+    mock.get_session_id.return_value = None
     return mock
 
 
@@ -291,6 +292,49 @@ class TestSearchAnalyticsInternalFlag:
         assert call_kwargs["is_internal"] is False
 
 
+class TestSearchAnalyticsSessionId:
+    """session_id is sourced from analytics.get_session_id(request)."""
+
+    async def test_session_id_propagated_when_helper_returns_value(
+        self, client: TestClient, mock_analytics: MagicMock
+    ):
+        # Given: get_session_id returns a session id (header was present)
+        mock_analytics.get_session_id.return_value = "session-search-abc"
+
+        with patch.object(
+            ArticleSearchService, "search", new_callable=AsyncMock
+        ) as mock_search:
+            mock_search.return_value = ([], 0)
+
+            # When: request is made with the PostHog session header
+            client.get(
+                "/api/v1/articles",
+                headers={"X-PostHog-Session-Id": "session-search-abc"},
+            )
+
+        # Then: session_id is passed through to capture_with_common_props
+        call_kwargs = mock_analytics.capture_with_common_props.call_args.kwargs
+        assert call_kwargs["session_id"] == "session-search-abc"
+
+    async def test_session_id_none_when_helper_returns_none(
+        self, client: TestClient, mock_analytics: MagicMock
+    ):
+        # Given: get_session_id returns None (header was absent)
+        mock_analytics.get_session_id.return_value = None
+
+        with patch.object(
+            ArticleSearchService, "search", new_callable=AsyncMock
+        ) as mock_search:
+            mock_search.return_value = ([], 0)
+
+            # When: request is made without the PostHog session header
+            client.get("/api/v1/articles")
+
+        # Then: session_id=None is passed (client method will then omit $session_id)
+        call_kwargs = mock_analytics.capture_with_common_props.call_args.kwargs
+        assert call_kwargs["session_id"] is None
+
+
 # ---------------------------------------------------------------------------
 # TestArticleDetailAnalytics
 # ---------------------------------------------------------------------------
@@ -406,4 +450,43 @@ class TestArticleDetailAnalytics:
         call_kwargs = mock_analytics.capture_with_common_props.call_args.kwargs
         assert call_kwargs["distinct_id"] == "frontend-posthog-id"
         assert call_kwargs["is_internal"] is True
+
+    async def test_session_id_propagated_when_helper_returns_value(
+        self, client: TestClient, mock_analytics: MagicMock
+    ):
+        # Given: get_session_id returns a value (X-PostHog-Session-Id was present)
+        mock_analytics.get_session_id.return_value = "session-detail-xyz"
+
+        with patch.object(
+            ArticleSearchService, "get_by_public_id", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = _make_detail_result(public_id=self._PUBLIC_ID)
+
+            # When: detail request is made with the PostHog session header
+            client.get(
+                f"/api/v1/articles/{self._PUBLIC_ID}",
+                headers={"X-PostHog-Session-Id": "session-detail-xyz"},
+            )
+
+        # Then: session_id is forwarded to capture_with_common_props
+        call_kwargs = mock_analytics.capture_with_common_props.call_args.kwargs
+        assert call_kwargs["session_id"] == "session-detail-xyz"
+
+    async def test_session_id_none_when_helper_returns_none(
+        self, client: TestClient, mock_analytics: MagicMock
+    ):
+        # Given: get_session_id returns None (no PostHog session header on request)
+        mock_analytics.get_session_id.return_value = None
+
+        with patch.object(
+            ArticleSearchService, "get_by_public_id", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = _make_detail_result(public_id=self._PUBLIC_ID)
+
+            # When: detail request is made without the session header
+            client.get(f"/api/v1/articles/{self._PUBLIC_ID}")
+
+        # Then: session_id=None is forwarded so client omits $session_id from event
+        call_kwargs = mock_analytics.capture_with_common_props.call_args.kwargs
+        assert call_kwargs["session_id"] is None
 


### PR DESCRIPTION
PostHog warned that server-side conversion events lacked $session_id, breaking session-scoped queries. The frontend now forwards X-PostHog-Session-Id on every API request; read it via a new get_session_id helper and inject PostHog's reserved $session_id property into events when the header is present (omitted otherwise so SSR and pre-session clients don't send placeholders).

Issues:
closes #258